### PR TITLE
bump to 0.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Bump upstream flux toolkit version to 0.7.6
+
 ## [0.1.0] - 2021-02-04
 
 - Initial release containing flux toolkit 0.5.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Breaking**: Changed values `images` subkeys from snake\_case camelCase
 - Bump upstream flux toolkit version to 0.7.7
 
 ## [0.1.0] - 2021-02-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Bump upstream flux toolkit version to 0.7.6
+- Bump upstream flux toolkit version to 0.7.7
 
 ## [0.1.0] - 2021-02-04
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ To change the encrypted file, one must have all public keys in their keychain. T
 
 ### Hints
 
-It's possible to use a 'common' gpg key which is only used for decryption on the cluster. Just add the key id to the `.sops.yaml` file and update the keys used as described in the section above. Now only the private key of the 'common' key needs to be present on the cluster.
+- When encrypting secrets with SOPS, tt's possible to use a 'common' gpg key which is only used for decryption on the cluster. Just add the key id to the `.sops.yaml` file and update the keys used as described in the section above. Now only the private key of the 'common' key needs to be present on the cluster.
 
 ## Update from upstream
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ To change the encrypted file, one must have all public keys in their keychain. T
 
 ### Hints
 
-- When encrypting secrets with SOPS, tt's possible to use a 'common' gpg key which is only used for decryption on the cluster. Just add the key id to the `.sops.yaml` file and update the keys used as described in the section above. Now only the private key of the 'common' key needs to be present on the cluster.
+- When encrypting secrets with SOPS, it's possible to use a 'common' gpg key which is only used for decryption on the cluster. Just add the key id to the `.sops.yaml` file and update the keys used as described in the section above. Now only the private key of the 'common' key needs to be present on the cluster.
 
 ## Update from upstream
 

--- a/hack/additional-resources/helm-controller-pv.yaml
+++ b/hack/additional-resources/helm-controller-pv.yaml
@@ -7,5 +7,4 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      #storage: '{{ .Values.volumes.helmControllerTemp.size | quote }}'
-      storage: 100Mi
+      storage: '{{ .Values.volumes.helmController.temp.size | quote }}'

--- a/hack/additional-resources/helm-controller-pv.yaml
+++ b/hack/additional-resources/helm-controller-pv.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: '{{ include "controllerVolumeName" (merge (dict "volumeName" "helm-controller-temp") .) | quote }}'
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      #storage: '{{ .Values.volumes.helmControllerTemp.size | quote }}'
+      storage: 100MiB

--- a/hack/additional-resources/helm-controller-pv.yaml
+++ b/hack/additional-resources/helm-controller-pv.yaml
@@ -8,4 +8,4 @@ spec:
   resources:
     requests:
       #storage: '{{ .Values.volumes.helmControllerTemp.size | quote }}'
-      storage: 100MiB
+      storage: 100Mi

--- a/hack/additional-resources/image-automation-controller-pv.yaml
+++ b/hack/additional-resources/image-automation-controller-pv.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: '{{ include "controllerVolumeName" (merge (dict "volumeName" "image-automation-controller-temp") .) | quote }}'
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100MiB

--- a/hack/additional-resources/image-automation-controller-pv.yaml
+++ b/hack/additional-resources/image-automation-controller-pv.yaml
@@ -7,4 +7,4 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 100Mi
+      storage: '{{ .Values.volumes.imageAutomationController.temp.size | quote }}'

--- a/hack/additional-resources/image-automation-controller-pv.yaml
+++ b/hack/additional-resources/image-automation-controller-pv.yaml
@@ -7,4 +7,4 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 100MiB
+      storage: 100Mi

--- a/hack/additional-resources/image-reflector-controller-pv.yaml
+++ b/hack/additional-resources/image-reflector-controller-pv.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: '{{ include "controllerVolumeName" (merge (dict "volumeName" "image-reflector-controller-temp") .) | quote }}'
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100MiB
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: '{{ include "controllerVolumeName" (merge (dict "volumeName" "image-reflector-controller-data") .) | quote }}'
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100MiB

--- a/hack/additional-resources/image-reflector-controller-pv.yaml
+++ b/hack/additional-resources/image-reflector-controller-pv.yaml
@@ -7,7 +7,7 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 100MiB
+      storage: 100Mi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -18,4 +18,4 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 100MiB
+      storage: 100Mi

--- a/hack/additional-resources/image-reflector-controller-pv.yaml
+++ b/hack/additional-resources/image-reflector-controller-pv.yaml
@@ -7,7 +7,7 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 100Mi
+      storage: '{{ .Values.volumes.imageReflectorController.temp.size | quote }}'
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -18,4 +18,4 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 100Mi
+      storage: '{{ .Values.volumes.imageReflectorController.data.size | quote }}'

--- a/hack/additional-resources/kustomize-controller-pv.yaml
+++ b/hack/additional-resources/kustomize-controller-pv.yaml
@@ -7,4 +7,4 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 100Mi
+      storage: '{{ .Values.volumes.kustomizeController.temp.size | quote }}'

--- a/hack/additional-resources/kustomize-controller-pv.yaml
+++ b/hack/additional-resources/kustomize-controller-pv.yaml
@@ -7,4 +7,4 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 100MiB
+      storage: 100Mi

--- a/hack/additional-resources/kustomize-controller-pv.yaml
+++ b/hack/additional-resources/kustomize-controller-pv.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: '{{ include "controllerVolumeName" (merge (dict "volumeName" "kustomize-controller-temp") .) | quote }}'
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100MiB

--- a/hack/additional-resources/notification-controller-pv.yaml
+++ b/hack/additional-resources/notification-controller-pv.yaml
@@ -7,4 +7,4 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 100Mi
+      storage: '{{ .Values.volumes.notificationController.temp.size | quote }}'

--- a/hack/additional-resources/notification-controller-pv.yaml
+++ b/hack/additional-resources/notification-controller-pv.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: '{{ include "controllerVolumeName" (merge (dict "volumeName" "notification-controller-temp") .) | quote }}'
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100MiB

--- a/hack/additional-resources/notification-controller-pv.yaml
+++ b/hack/additional-resources/notification-controller-pv.yaml
@@ -7,4 +7,4 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 100MiB
+      storage: 100Mi

--- a/hack/additional-resources/pvc-psp.yaml
+++ b/hack/additional-resources/pvc-psp.yaml
@@ -1,0 +1,22 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: '{{ include "name" . }}-pvc-psp'
+spec:
+  privileged: false
+  seLinux:
+    rule: RunAsAny
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  runAsUser:
+    rule: MustRunAsNonRoot
+  volumes:
+  - 'persistentVolumeClaim'

--- a/hack/additional-resources/pvc-psp.yaml
+++ b/hack/additional-resources/pvc-psp.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: '{{ include "name" . }}-pvc-psp'
+  name: '{{ printf "%s-pvc-psp" (include "name" .) | quote }}'
 spec:
   privileged: false
   seLinux:

--- a/hack/additional-resources/pvc-psp.yaml
+++ b/hack/additional-resources/pvc-psp.yaml
@@ -3,6 +3,7 @@ kind: PodSecurityPolicy
 metadata:
   name: '{{ printf "%s-pvc-psp" (include "name" .) | quote }}'
 spec:
+  allowPrivilegeEscalation: false
   privileged: false
   seLinux:
     rule: RunAsAny

--- a/hack/additional-resources/pvc-psp.yaml
+++ b/hack/additional-resources/pvc-psp.yaml
@@ -21,3 +21,4 @@ spec:
     rule: MustRunAsNonRoot
   volumes:
   - 'persistentVolumeClaim'
+  - 'secret'

--- a/hack/additional-resources/source-controller-pv.yaml
+++ b/hack/additional-resources/source-controller-pv.yaml
@@ -7,7 +7,7 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 100MiB
+      storage: 100Mi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -18,4 +18,4 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 100MiB
+      storage: 100Mi

--- a/hack/additional-resources/source-controller-pv.yaml
+++ b/hack/additional-resources/source-controller-pv.yaml
@@ -7,7 +7,7 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 100Mi
+      storage: '{{ .Values.volumes.sourceController.temp.size | quote }}'
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -18,4 +18,4 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 100Mi
+      storage: '{{ .Values.volumes.sourceController.data.size | quote }}'

--- a/hack/additional-resources/source-controller-pv.yaml
+++ b/hack/additional-resources/source-controller-pv.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: '{{ include "controllerVolumeName" (merge (dict "volumeName" "source-controller-temp") .) | quote }}'
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100MiB
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: '{{ include "controllerVolumeName" (merge (dict "volumeName" "source-controller-data") .) | quote }}'
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100MiB

--- a/hack/kustomization.yaml
+++ b/hack/kustomization.yaml
@@ -10,17 +10,17 @@ transformers:
 
 images:
 - name: fluxcd/helm-controller
-  newName: "{{ .Values.images.registry }}/{{ .Values.images.helm_controller.image }}"
+  newName: "{{ .Values.images.registry }}/{{ .Values.images.helmController.image }}"
 - name: fluxcd/kustomize-controller
-  newName: "{{ .Values.images.registry }}/{{ .Values.images.kustomize_controller.image }}"
+  newName: "{{ .Values.images.registry }}/{{ .Values.images.kustomizeController.image }}"
 - name: fluxcd/source-controller
-  newName: "{{ .Values.images.registry }}/{{ .Values.images.source_controller.image }}"
+  newName: "{{ .Values.images.registry }}/{{ .Values.images.sourceController.image }}"
 - name: fluxcd/notification-controller
-  newName: "{{ .Values.images.registry }}/{{ .Values.images.notification_controller.image }}"
+  newName: "{{ .Values.images.registry }}/{{ .Values.images.notificationController.image }}"
 - name: fluxcd/image-automation-controller
-  newName: "{{ .Values.images.registry }}/{{ .Values.images.image_automation_controller.image }}"
+  newName: "{{ .Values.images.registry }}/{{ .Values.images.imageAutomationController.image }}"
 - name: fluxcd/image-reflector-controller
-  newName: "{{ .Values.images.registry }}/{{ .Values.images.image_reflector_controller.image }}"
+  newName: "{{ .Values.images.registry }}/{{ .Values.images.imageReflectorController.image }}"
 
 
 resources:

--- a/hack/kustomization.yaml
+++ b/hack/kustomization.yaml
@@ -24,7 +24,7 @@ images:
 
 
 resources:
-- https://github.com/fluxcd/flux2/releases/download/v0.7.6/install.yaml
+- https://github.com/fluxcd/flux2/releases/download/v0.7.7/install.yaml
 - ./additional-resources/helm-controller-pv.yaml
 - ./additional-resources/image-automation-controller-pv.yaml
 - ./additional-resources/image-reflector-controller-pv.yaml

--- a/hack/kustomization.yaml
+++ b/hack/kustomization.yaml
@@ -47,3 +47,9 @@ patches:
     kind: ClusterRole
     name: crd-controller
     labelSelector: "app.kubernetes.io/instance=flux-system"
+- path: ./patches/controller-securitycontext-patch.yaml
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    labelSelector: "app.kubernetes.io/instance=flux-system"

--- a/hack/kustomization.yaml
+++ b/hack/kustomization.yaml
@@ -24,4 +24,4 @@ images:
 
 
 resources:
-- https://github.com/fluxcd/flux2/releases/download/v0.5.9/install.yaml
+- https://github.com/fluxcd/flux2/releases/download/v0.7.6/install.yaml

--- a/hack/kustomization.yaml
+++ b/hack/kustomization.yaml
@@ -25,3 +25,17 @@ images:
 
 resources:
 - https://github.com/fluxcd/flux2/releases/download/v0.7.6/install.yaml
+- ./additional-resources/helm-controller-pv.yaml
+- ./additional-resources/image-automation-controller-pv.yaml
+- ./additional-resources/image-reflector-controller-pv.yaml
+- ./additional-resources/kustomize-controller-pv.yaml
+- ./additional-resources/notification-controller-pv.yaml
+- ./additional-resources/source-controller-pv.yaml
+
+patches:
+- path: ./patches/helm-controller-patch.yaml
+- path: ./patches/image-automation-controller-patch.yaml
+- path: ./patches/image-reflector-controller-patch.yaml
+- path: ./patches/kustomize-controller-patch.yaml
+- path: ./patches/notification-controller-patch.yaml
+- path: ./patches/source-controller-patch.yaml

--- a/hack/kustomization.yaml
+++ b/hack/kustomization.yaml
@@ -31,6 +31,7 @@ resources:
 - ./additional-resources/kustomize-controller-pv.yaml
 - ./additional-resources/notification-controller-pv.yaml
 - ./additional-resources/source-controller-pv.yaml
+- ./additional-resources/pvc-psp.yaml
 
 patches:
 - path: ./patches/helm-controller-patch.yaml
@@ -39,3 +40,10 @@ patches:
 - path: ./patches/kustomize-controller-patch.yaml
 - path: ./patches/notification-controller-patch.yaml
 - path: ./patches/source-controller-patch.yaml
+- path: ./patches/crd-controller-cluster-role-patch.yaml
+  target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: ClusterRole
+    name: crd-controller
+    labelSelector: "app.kubernetes.io/instance=flux-system"

--- a/hack/patches/controller-securitycontext-patch.yaml
+++ b/hack/patches/controller-securitycontext-patch.yaml
@@ -3,4 +3,4 @@
   value:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
-    runAs: 100
+    runAsUser: 100

--- a/hack/patches/controller-securitycontext-patch.yaml
+++ b/hack/patches/controller-securitycontext-patch.yaml
@@ -1,0 +1,6 @@
+- op: add
+  path: /spec/template/spec/containers/0/securityContext
+  value:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    runAs: 100

--- a/hack/patches/crd-controller-cluster-role-patch.yaml
+++ b/hack/patches/crd-controller-cluster-role-patch.yaml
@@ -1,0 +1,7 @@
+- op: add
+  path: /rules/-
+  value:
+    apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs: ['use']
+    resourceNames: ['{{ printf "%s-pvc-psp" (include "name" .) | quote }}']

--- a/hack/patches/helm-controller-patch.yaml
+++ b/hack/patches/helm-controller-patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: flux-system
+    control-plane: controller
+  name: helm-controller
+  namespace: flux-system
+spec:
+  template:
+    spec:
+      volumes:
+        - name: temp
+          persistentVolumeClaim:
+            claimName: '{{ include "controllerVolumeName" (merge (dict "volumeName" "helm-controller-temp") .) | quote }}'
+          emptyDir: null

--- a/hack/patches/image-automation-controller-patch.yaml
+++ b/hack/patches/image-automation-controller-patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: flux-system
+    control-plane: controller
+  name: image-automation-controller
+  namespace: flux-system
+spec:
+  template:
+    spec:
+      volumes:
+        - name: temp
+          persistentVolumeClaim:
+            claimName: '{{ include "controllerVolumeName" (merge (dict "volumeName" "image-automation-controller-temp") .) | quote }}'
+          emptyDir: null

--- a/hack/patches/image-reflector-controller-patch.yaml
+++ b/hack/patches/image-reflector-controller-patch.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: flux-system
+    control-plane: controller
+  name: image-reflector-controller
+  namespace: flux-system
+spec:
+  template:
+    spec:
+      volumes:
+        - name: temp
+          persistentVolumeClaim:
+            claimName: '{{ include "controllerVolumeName" (merge (dict "volumeName" "image-reflector-controller-temp") .) | quote }}'
+          emptyDir: null
+        - name: data
+          persistentVolumeClaim:
+            claimName: '{{ include "controllerVolumeName" (merge (dict "volumeName" "image-reflector-controller-data") .) | quote }}'
+          emptyDir: null

--- a/hack/patches/kustomize-controller-patch.yaml
+++ b/hack/patches/kustomize-controller-patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: flux-system
+    control-plane: controller
+  name: kustomize-controller
+  namespace: flux-system
+spec:
+  template:
+    spec:
+      volumes:
+        - name: temp
+          persistentVolumeClaim:
+            claimName: '{{ include "controllerVolumeName" (merge (dict "volumeName" "kustomize-controller-temp") .) | quote }}'
+          emptyDir: null

--- a/hack/patches/notification-controller-patch.yaml
+++ b/hack/patches/notification-controller-patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: flux-system
+    control-plane: controller
+  name: notification-controller
+  namespace: flux-system
+spec:
+  template:
+    spec:
+      volumes:
+        - name: temp
+          persistentVolumeClaim:
+            claimName: '{{ include "controllerVolumeName" (merge (dict "volumeName" "notification-controller-temp") .) | quote }}'
+          emptyDir: null

--- a/hack/patches/source-controller-patch.yaml
+++ b/hack/patches/source-controller-patch.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: flux-system
+    control-plane: controller
+  name: source-controller
+  namespace: flux-system
+spec:
+  template:
+    spec:
+      volumes:
+        - name: tmp
+          persistentVolumeClaim:
+            claimName: '{{ include "controllerVolumeName" (merge (dict "volumeName" "source-controller-temp") .) | quote }}'
+          emptyDir: null
+        - name: data
+          persistentVolumeClaim:
+            claimName: '{{ include "controllerVolumeName" (merge (dict "volumeName" "source-controller-data") .) | quote }}'
+          emptyDir: null

--- a/helm/flux-app/Chart.yaml
+++ b/helm/flux-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.7.6
+appVersion: 0.7.7
 description: A Helm chart for flux
 engine: gotpl
 home: https://github.com/giantswarm/flux-app

--- a/helm/flux-app/Chart.yaml
+++ b/helm/flux-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.5.9
+appVersion: 0.7.6
 description: A Helm chart for flux
 engine: gotpl
 home: https://github.com/giantswarm/flux-app

--- a/helm/flux-app/crds/alert.yaml
+++ b/helm/flux-app/crds/alert.yaml
@@ -16,140 +16,145 @@ spec:
     singular: alert
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: Alert is the Schema for the alerts API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AlertSpec defines an alerting rule for events involving a list of objects
-            properties:
-              eventSeverity:
-                default: info
-                description: Filter events based on severity, defaults to ('info'). If set to 'info' no events will be filtered.
-                enum:
-                - info
-                - error
-                type: string
-              eventSources:
-                description: Filter events based on the involved objects
-                items:
-                  description: CrossNamespaceObjectReference contains enough information to let you locate the typed referenced object at cluster level
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: Alert is the Schema for the alerts API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: AlertSpec defines an alerting rule for events involving a list of objects
+              properties:
+                eventSeverity:
+                  default: info
+                  description: Filter events based on severity, defaults to ('info'). If set to 'info' no events will be filtered.
+                  enum:
+                    - info
+                    - error
+                  type: string
+                eventSources:
+                  description: Filter events based on the involved objects
+                  items:
+                    description: CrossNamespaceObjectReference contains enough information to let you locate the typed referenced object at cluster level
+                    properties:
+                      apiVersion:
+                        description: API version of the referent
+                        type: string
+                      kind:
+                        description: Kind of the referent
+                        enum:
+                          - Bucket
+                          - GitRepository
+                          - Kustomization
+                          - HelmRelease
+                          - HelmChart
+                          - HelmRepository
+                          - ImageRepository
+                          - ImagePolicy
+                          - ImageUpdateAutomation
+                        type: string
+                      name:
+                        description: Name of the referent
+                        maxLength: 53
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: Namespace of the referent
+                        maxLength: 53
+                        minLength: 1
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                providerRef:
+                  description: Send events using this provider
                   properties:
-                    apiVersion:
-                      description: API version of the referent
-                      type: string
-                    kind:
-                      description: Kind of the referent
-                      enum:
-                      - Bucket
-                      - GitRepository
-                      - Kustomization
-                      - HelmRelease
-                      - HelmChart
-                      - HelmRepository
-                      type: string
                     name:
                       description: Name of the referent
-                      maxLength: 53
-                      minLength: 1
-                      type: string
-                    namespace:
-                      description: Namespace of the referent
-                      maxLength: 53
-                      minLength: 1
                       type: string
                   required:
-                  - name
+                    - name
                   type: object
-                type: array
-              providerRef:
-                description: Send events using this provider
-                properties:
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                    type: string
-                type: object
-              summary:
-                description: Short description of the impact and affected cluster.
-                type: string
-              suspend:
-                description: This flag tells the controller to suspend subsequent events dispatching. Defaults to false.
-                type: boolean
-            required:
-            - eventSources
-            - providerRef
-            type: object
-          status:
-            description: AlertStatus defines the observed state of Alert
-            properties:
-              conditions:
-                items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human readable message indicating details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                summary:
+                  description: Short description of the impact and affected cluster.
+                  type: string
+                suspend:
+                  description: This flag tells the controller to suspend subsequent events dispatching. Defaults to false.
+                  type: boolean
+              required:
+                - eventSources
+                - providerRef
+              type: object
+            status:
+              description: AlertStatus defines the observed state of Alert
+              properties:
+                conditions:
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/helm/flux-app/crds/bucket.yaml
+++ b/helm/flux-app/crds/bucket.yaml
@@ -16,165 +16,167 @@ spec:
     singular: bucket
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.url
-      name: URL
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: Bucket is the Schema for the buckets API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: BucketSpec defines the desired state of an S3 compatible bucket
-            properties:
-              bucketName:
-                description: The bucket name.
-                type: string
-              endpoint:
-                description: The bucket endpoint address.
-                type: string
-              ignore:
-                description: Ignore overrides the set of excluded patterns in the .sourceignore format (which is the same as .gitignore). If not provided, a default will be used, consult the documentation for your version to find out what those are.
-                type: string
-              insecure:
-                description: Insecure allows connecting to a non-TLS S3 HTTP endpoint.
-                type: boolean
-              interval:
-                description: The interval at which to check for bucket updates.
-                type: string
-              provider:
-                default: generic
-                description: The S3 compatible storage provider name, default ('generic').
-                enum:
-                - generic
-                - aws
-                type: string
-              region:
-                description: The bucket region.
-                type: string
-              secretRef:
-                description: The name of the secret containing authentication credentials for the Bucket.
-                properties:
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                    type: string
-                type: object
-              suspend:
-                description: This flag tells the controller to suspend the reconciliation of this source.
-                type: boolean
-              timeout:
-                default: 20s
-                description: The timeout for download operations, defaults to 20s.
-                type: string
-            required:
-            - bucketName
-            - endpoint
-            - interval
-            type: object
-          status:
-            description: BucketStatus defines the observed state of a bucket
-            properties:
-              artifact:
-                description: Artifact represents the output of the last successful Bucket sync.
-                properties:
-                  checksum:
-                    description: Checksum is the SHA1 checksum of the artifact.
-                    type: string
-                  lastUpdateTime:
-                    description: LastUpdateTime is the timestamp corresponding to the last update of this artifact.
-                    format: date-time
-                    type: string
-                  path:
-                    description: Path is the relative file path of this artifact.
-                    type: string
-                  revision:
-                    description: Revision is a human readable identifier traceable in the origin source system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm chart version, etc.
-                    type: string
-                  url:
-                    description: URL is the HTTP address of this artifact.
-                    type: string
-                required:
-                - path
-                - url
-                type: object
-              conditions:
-                description: Conditions holds the conditions for the Bucket.
-                items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+    - additionalPrinterColumns:
+        - jsonPath: .spec.url
+          name: URL
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: Bucket is the Schema for the buckets API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: BucketSpec defines the desired state of an S3 compatible bucket
+              properties:
+                bucketName:
+                  description: The bucket name.
+                  type: string
+                endpoint:
+                  description: The bucket endpoint address.
+                  type: string
+                ignore:
+                  description: Ignore overrides the set of excluded patterns in the .sourceignore format (which is the same as .gitignore). If not provided, a default will be used, consult the documentation for your version to find out what those are.
+                  type: string
+                insecure:
+                  description: Insecure allows connecting to a non-TLS S3 HTTP endpoint.
+                  type: boolean
+                interval:
+                  description: The interval at which to check for bucket updates.
+                  type: string
+                provider:
+                  default: generic
+                  description: The S3 compatible storage provider name, default ('generic').
+                  enum:
+                    - generic
+                    - aws
+                  type: string
+                region:
+                  description: The bucket region.
+                  type: string
+                secretRef:
+                  description: The name of the secret containing authentication credentials for the Bucket.
                   properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human readable message indicating details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    name:
+                      description: Name of the referent
                       type: string
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    - name
                   type: object
-                type: array
-              lastHandledReconcileAt:
-                description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change can be detected.
-                type: string
-              observedGeneration:
-                description: ObservedGeneration is the last observed generation.
-                format: int64
-                type: integer
-              url:
-                description: URL is the download link for the artifact output of the last Bucket sync.
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                suspend:
+                  description: This flag tells the controller to suspend the reconciliation of this source.
+                  type: boolean
+                timeout:
+                  default: 20s
+                  description: The timeout for download operations, defaults to 20s.
+                  type: string
+              required:
+                - bucketName
+                - endpoint
+                - interval
+              type: object
+            status:
+              description: BucketStatus defines the observed state of a bucket
+              properties:
+                artifact:
+                  description: Artifact represents the output of the last successful Bucket sync.
+                  properties:
+                    checksum:
+                      description: Checksum is the SHA1 checksum of the artifact.
+                      type: string
+                    lastUpdateTime:
+                      description: LastUpdateTime is the timestamp corresponding to the last update of this artifact.
+                      format: date-time
+                      type: string
+                    path:
+                      description: Path is the relative file path of this artifact.
+                      type: string
+                    revision:
+                      description: Revision is a human readable identifier traceable in the origin source system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm chart version, etc.
+                      type: string
+                    url:
+                      description: URL is the HTTP address of this artifact.
+                      type: string
+                  required:
+                    - path
+                    - url
+                  type: object
+                conditions:
+                  description: Conditions holds the conditions for the Bucket.
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                lastHandledReconcileAt:
+                  description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change can be detected.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation.
+                  format: int64
+                  type: integer
+                url:
+                  description: URL is the download link for the artifact output of the last Bucket sync.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/helm/flux-app/crds/gitrepository.yaml
+++ b/helm/flux-app/crds/gitrepository.yaml
@@ -16,191 +16,195 @@ spec:
     singular: gitrepository
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.url
-      name: URL
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: GitRepository is the Schema for the gitrepositories API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: GitRepositorySpec defines the desired state of a Git repository.
-            properties:
-              gitImplementation:
-                default: go-git
-                description: Determines which git client library to use. Defaults to go-git, valid values are ('go-git', 'libgit2').
-                enum:
-                - go-git
-                - libgit2
-                type: string
-              ignore:
-                description: Ignore overrides the set of excluded patterns in the .sourceignore format (which is the same as .gitignore). If not provided, a default will be used, consult the documentation for your version to find out what those are.
-                type: string
-              interval:
-                description: The interval at which to check for repository updates.
-                type: string
-              ref:
-                description: The Git reference to checkout and monitor for changes, defaults to master branch.
-                properties:
-                  branch:
-                    default: master
-                    description: The Git branch to checkout, defaults to master.
-                    type: string
-                  commit:
-                    description: The Git commit SHA to checkout, if specified Tag filters will be ignored.
-                    type: string
-                  semver:
-                    description: The Git tag semver expression, takes precedence over Tag.
-                    type: string
-                  tag:
-                    description: The Git tag to checkout, takes precedence over Branch.
-                    type: string
-                type: object
-              secretRef:
-                description: The secret name containing the Git credentials. For HTTPS repositories the secret must contain username and password fields. For SSH repositories the secret must contain identity, identity.pub and known_hosts fields.
-                properties:
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                    type: string
-                type: object
-              suspend:
-                description: This flag tells the controller to suspend the reconciliation of this source.
-                type: boolean
-              timeout:
-                default: 20s
-                description: The timeout for remote Git operations like cloning, defaults to 20s.
-                type: string
-              url:
-                description: The repository URL, can be a HTTP/S or SSH address.
-                pattern: ^(http|https|ssh)://
-                type: string
-              verify:
-                description: Verify OpenPGP signature for the Git commit HEAD points to.
-                properties:
-                  mode:
-                    description: Mode describes what git object should be verified, currently ('head').
-                    enum:
-                    - head
-                    type: string
-                  secretRef:
-                    description: The secret name containing the public keys of all trusted Git authors.
-                    properties:
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                        type: string
-                    type: object
-                required:
-                - mode
-                type: object
-            required:
-            - interval
-            - url
-            type: object
-          status:
-            description: GitRepositoryStatus defines the observed state of a Git repository.
-            properties:
-              artifact:
-                description: Artifact represents the output of the last successful repository sync.
-                properties:
-                  checksum:
-                    description: Checksum is the SHA1 checksum of the artifact.
-                    type: string
-                  lastUpdateTime:
-                    description: LastUpdateTime is the timestamp corresponding to the last update of this artifact.
-                    format: date-time
-                    type: string
-                  path:
-                    description: Path is the relative file path of this artifact.
-                    type: string
-                  revision:
-                    description: Revision is a human readable identifier traceable in the origin source system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm chart version, etc.
-                    type: string
-                  url:
-                    description: URL is the HTTP address of this artifact.
-                    type: string
-                required:
-                - path
-                - url
-                type: object
-              conditions:
-                description: Conditions holds the conditions for the GitRepository.
-                items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+    - additionalPrinterColumns:
+        - jsonPath: .spec.url
+          name: URL
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: GitRepository is the Schema for the gitrepositories API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: GitRepositorySpec defines the desired state of a Git repository.
+              properties:
+                gitImplementation:
+                  default: go-git
+                  description: Determines which git client library to use. Defaults to go-git, valid values are ('go-git', 'libgit2').
+                  enum:
+                    - go-git
+                    - libgit2
+                  type: string
+                ignore:
+                  description: Ignore overrides the set of excluded patterns in the .sourceignore format (which is the same as .gitignore). If not provided, a default will be used, consult the documentation for your version to find out what those are.
+                  type: string
+                interval:
+                  description: The interval at which to check for repository updates.
+                  type: string
+                ref:
+                  description: The Git reference to checkout and monitor for changes, defaults to master branch.
                   properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
+                    branch:
+                      default: master
+                      description: The Git branch to checkout, defaults to master.
                       type: string
-                    message:
-                      description: message is a human readable message indicating details about the transition. This may be an empty string.
-                      maxLength: 32768
+                    commit:
+                      description: The Git commit SHA to checkout, if specified Tag filters will be ignored.
                       type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                    semver:
+                      description: The Git tag semver expression, takes precedence over Tag.
                       type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
+                    tag:
+                      description: The Git tag to checkout, takes precedence over Branch.
                       type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                  type: object
+                secretRef:
+                  description: The secret name containing the Git credentials. For HTTPS repositories the secret must contain username and password fields. For SSH repositories the secret must contain identity, identity.pub and known_hosts fields.
+                  properties:
+                    name:
+                      description: Name of the referent
                       type: string
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    - name
                   type: object
-                type: array
-              lastHandledReconcileAt:
-                description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change can be detected.
-                type: string
-              observedGeneration:
-                description: ObservedGeneration is the last observed generation.
-                format: int64
-                type: integer
-              url:
-                description: URL is the download link for the artifact output of the last repository sync.
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                suspend:
+                  description: This flag tells the controller to suspend the reconciliation of this source.
+                  type: boolean
+                timeout:
+                  default: 20s
+                  description: The timeout for remote Git operations like cloning, defaults to 20s.
+                  type: string
+                url:
+                  description: The repository URL, can be a HTTP/S or SSH address.
+                  pattern: ^(http|https|ssh)://
+                  type: string
+                verify:
+                  description: Verify OpenPGP signature for the Git commit HEAD points to.
+                  properties:
+                    mode:
+                      description: Mode describes what git object should be verified, currently ('head').
+                      enum:
+                        - head
+                      type: string
+                    secretRef:
+                      description: The secret name containing the public keys of all trusted Git authors.
+                      properties:
+                        name:
+                          description: Name of the referent
+                          type: string
+                      required:
+                        - name
+                      type: object
+                  required:
+                    - mode
+                  type: object
+              required:
+                - interval
+                - url
+              type: object
+            status:
+              description: GitRepositoryStatus defines the observed state of a Git repository.
+              properties:
+                artifact:
+                  description: Artifact represents the output of the last successful repository sync.
+                  properties:
+                    checksum:
+                      description: Checksum is the SHA1 checksum of the artifact.
+                      type: string
+                    lastUpdateTime:
+                      description: LastUpdateTime is the timestamp corresponding to the last update of this artifact.
+                      format: date-time
+                      type: string
+                    path:
+                      description: Path is the relative file path of this artifact.
+                      type: string
+                    revision:
+                      description: Revision is a human readable identifier traceable in the origin source system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm chart version, etc.
+                      type: string
+                    url:
+                      description: URL is the HTTP address of this artifact.
+                      type: string
+                  required:
+                    - path
+                    - url
+                  type: object
+                conditions:
+                  description: Conditions holds the conditions for the GitRepository.
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                lastHandledReconcileAt:
+                  description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change can be detected.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation.
+                  format: int64
+                  type: integer
+                url:
+                  description: URL is the download link for the artifact output of the last repository sync.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/helm/flux-app/crds/helmchart.yaml
+++ b/helm/flux-app/crds/helmchart.yaml
@@ -16,171 +16,171 @@ spec:
     singular: helmchart
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.chart
-      name: Chart
-      type: string
-    - jsonPath: .spec.version
-      name: Version
-      type: string
-    - jsonPath: .spec.sourceRef.kind
-      name: Source Kind
-      type: string
-    - jsonPath: .spec.sourceRef.name
-      name: Source Name
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: HelmChart is the Schema for the helmcharts API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: HelmChartSpec defines the desired state of a Helm chart.
-            properties:
-              chart:
-                description: The name or path the Helm chart is available at in the SourceRef.
-                type: string
-              interval:
-                description: The interval at which to check the Source for updates.
-                type: string
-              sourceRef:
-                description: The reference to the Source the chart is available at.
-                properties:
-                  apiVersion:
-                    description: APIVersion of the referent.
-                    type: string
-                  kind:
-                    description: Kind of the referent, valid values are ('HelmRepository', 'GitRepository', 'Bucket').
-                    enum:
-                    - HelmRepository
-                    - GitRepository
-                    - Bucket
-                    type: string
-                  name:
-                    description: Name of the referent.
-                    type: string
-                required:
-                - kind
-                - name
-                type: object
-              suspend:
-                description: This flag tells the controller to suspend the reconciliation of this source.
-                type: boolean
-              valuesFile:
-                description: Alternative values file to use as the default chart values, expected to be a relative path in the SourceRef. Ignored when omitted.
-                type: string
-              version:
-                default: '*'
-                description: The chart version semver expression, ignored for charts from GitRepository and Bucket sources. Defaults to latest when omitted.
-                type: string
-            required:
-            - chart
-            - interval
-            - sourceRef
-            type: object
-          status:
-            description: HelmChartStatus defines the observed state of the HelmChart.
-            properties:
-              artifact:
-                description: Artifact represents the output of the last successful chart sync.
-                properties:
-                  checksum:
-                    description: Checksum is the SHA1 checksum of the artifact.
-                    type: string
-                  lastUpdateTime:
-                    description: LastUpdateTime is the timestamp corresponding to the last update of this artifact.
-                    format: date-time
-                    type: string
-                  path:
-                    description: Path is the relative file path of this artifact.
-                    type: string
-                  revision:
-                    description: Revision is a human readable identifier traceable in the origin source system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm chart version, etc.
-                    type: string
-                  url:
-                    description: URL is the HTTP address of this artifact.
-                    type: string
-                required:
-                - path
-                - url
-                type: object
-              conditions:
-                description: Conditions holds the conditions for the HelmChart.
-                items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+    - additionalPrinterColumns:
+        - jsonPath: .spec.chart
+          name: Chart
+          type: string
+        - jsonPath: .spec.version
+          name: Version
+          type: string
+        - jsonPath: .spec.sourceRef.kind
+          name: Source Kind
+          type: string
+        - jsonPath: .spec.sourceRef.name
+          name: Source Name
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: HelmChart is the Schema for the helmcharts API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: HelmChartSpec defines the desired state of a Helm chart.
+              properties:
+                chart:
+                  description: The name or path the Helm chart is available at in the SourceRef.
+                  type: string
+                interval:
+                  description: The interval at which to check the Source for updates.
+                  type: string
+                sourceRef:
+                  description: The reference to the Source the chart is available at.
                   properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
+                    apiVersion:
+                      description: APIVersion of the referent.
                       type: string
-                    message:
-                      description: message is a human readable message indicating details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
+                    kind:
+                      description: Kind of the referent, valid values are ('HelmRepository', 'GitRepository', 'Bucket').
                       enum:
-                      - "True"
-                      - "False"
-                      - Unknown
+                        - HelmRepository
+                        - GitRepository
+                        - Bucket
                       type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    name:
+                      description: Name of the referent.
                       type: string
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    - kind
+                    - name
                   type: object
-                type: array
-              lastHandledReconcileAt:
-                description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change can be detected.
-                type: string
-              observedGeneration:
-                description: ObservedGeneration is the last observed generation.
-                format: int64
-                type: integer
-              url:
-                description: URL is the download link for the last chart pulled.
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                suspend:
+                  description: This flag tells the controller to suspend the reconciliation of this source.
+                  type: boolean
+                valuesFile:
+                  description: Alternative values file to use as the default chart values, expected to be a relative path in the SourceRef. Ignored when omitted.
+                  type: string
+                version:
+                  default: '*'
+                  description: The chart version semver expression, ignored for charts from GitRepository and Bucket sources. Defaults to latest when omitted.
+                  type: string
+              required:
+                - chart
+                - interval
+                - sourceRef
+              type: object
+            status:
+              description: HelmChartStatus defines the observed state of the HelmChart.
+              properties:
+                artifact:
+                  description: Artifact represents the output of the last successful chart sync.
+                  properties:
+                    checksum:
+                      description: Checksum is the SHA1 checksum of the artifact.
+                      type: string
+                    lastUpdateTime:
+                      description: LastUpdateTime is the timestamp corresponding to the last update of this artifact.
+                      format: date-time
+                      type: string
+                    path:
+                      description: Path is the relative file path of this artifact.
+                      type: string
+                    revision:
+                      description: Revision is a human readable identifier traceable in the origin source system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm chart version, etc.
+                      type: string
+                    url:
+                      description: URL is the HTTP address of this artifact.
+                      type: string
+                  required:
+                    - path
+                    - url
+                  type: object
+                conditions:
+                  description: Conditions holds the conditions for the HelmChart.
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                lastHandledReconcileAt:
+                  description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change can be detected.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation.
+                  format: int64
+                  type: integer
+                url:
+                  description: URL is the download link for the last chart pulled.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/helm/flux-app/crds/helmrelease.yaml
+++ b/helm/flux-app/crds/helmrelease.yaml
@@ -14,393 +14,400 @@ spec:
     listKind: HelmReleaseList
     plural: helmreleases
     shortNames:
-    - hr
+      - hr
     singular: helmrelease
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v2beta1
-    schema:
-      openAPIV3Schema:
-        description: HelmRelease is the Schema for the helmreleases API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: HelmReleaseSpec defines the desired state of a Helm release.
-            properties:
-              chart:
-                description: Chart defines the template of the v1beta1.HelmChart that should be created for this HelmRelease.
-                properties:
-                  spec:
-                    description: Spec holds the template for the v1beta1.HelmChartSpec for this HelmRelease.
-                    properties:
-                      chart:
-                        description: The name or path the Helm chart is available at in the SourceRef.
-                        type: string
-                      interval:
-                        description: Interval at which to check the v1beta1.Source for updates. Defaults to 'HelmReleaseSpec.Interval'.
-                        type: string
-                      sourceRef:
-                        description: The name and namespace of the v1beta1.Source the chart is available at.
-                        properties:
-                          apiVersion:
-                            description: APIVersion of the referent.
-                            type: string
-                          kind:
-                            description: Kind of the referent.
-                            enum:
-                            - HelmRepository
-                            - GitRepository
-                            - Bucket
-                            type: string
-                          name:
-                            description: Name of the referent.
-                            maxLength: 253
-                            minLength: 1
-                            type: string
-                          namespace:
-                            description: Namespace of the referent.
-                            maxLength: 63
-                            minLength: 1
-                            type: string
-                        required:
-                        - name
-                        type: object
-                      valuesFile:
-                        description: Alternative values file to use as the default chart values, expected to be a relative path in the SourceRef. Ignored when omitted.
-                        type: string
-                      version:
-                        default: '*'
-                        description: Version semver expression, ignored for charts from v1beta1.GitRepository and v1beta1.Bucket sources. Defaults to latest when omitted.
-                        type: string
-                    required:
-                    - chart
-                    - sourceRef
-                    type: object
-                required:
-                - spec
-                type: object
-              dependsOn:
-                description: DependsOn may contain a dependency.CrossNamespaceDependencyReference slice with references to HelmRelease resources that must be ready before this HelmRelease can be reconciled.
-                items:
-                  description: CrossNamespaceDependencyReference holds the reference to a dependency.
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v2beta1
+      schema:
+        openAPIV3Schema:
+          description: HelmRelease is the Schema for the helmreleases API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: HelmReleaseSpec defines the desired state of a Helm release.
+              properties:
+                chart:
+                  description: Chart defines the template of the v1beta1.HelmChart that should be created for this HelmRelease.
                   properties:
-                    name:
-                      description: Name holds the name reference of a dependency.
-                      type: string
-                    namespace:
-                      description: Namespace holds the namespace reference of a dependency.
-                      type: string
+                    spec:
+                      description: Spec holds the template for the v1beta1.HelmChartSpec for this HelmRelease.
+                      properties:
+                        chart:
+                          description: The name or path the Helm chart is available at in the SourceRef.
+                          type: string
+                        interval:
+                          description: Interval at which to check the v1beta1.Source for updates. Defaults to 'HelmReleaseSpec.Interval'.
+                          type: string
+                        sourceRef:
+                          description: The name and namespace of the v1beta1.Source the chart is available at.
+                          properties:
+                            apiVersion:
+                              description: APIVersion of the referent.
+                              type: string
+                            kind:
+                              description: Kind of the referent.
+                              enum:
+                                - HelmRepository
+                                - GitRepository
+                                - Bucket
+                              type: string
+                            name:
+                              description: Name of the referent.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            namespace:
+                              description: Namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        valuesFile:
+                          description: Alternative values file to use as the default chart values, expected to be a relative path in the SourceRef. Ignored when omitted.
+                          type: string
+                        version:
+                          default: '*'
+                          description: Version semver expression, ignored for charts from v1beta1.GitRepository and v1beta1.Bucket sources. Defaults to latest when omitted.
+                          type: string
+                      required:
+                        - chart
+                        - sourceRef
+                      type: object
                   required:
-                  - name
+                    - spec
                   type: object
-                type: array
-              install:
-                description: Install holds the configuration for Helm install actions for this HelmRelease.
-                properties:
-                  createNamespace:
-                    description: CreateNamespace tells the Helm install action to create the HelmReleaseSpec.TargetNamespace if it does not exist yet. On uninstall, the namespace will not be garbage collected.
-                    type: boolean
-                  disableHooks:
-                    description: DisableHooks prevents hooks from running during the Helm install action.
-                    type: boolean
-                  disableOpenAPIValidation:
-                    description: DisableOpenAPIValidation prevents the Helm install action from validating rendered templates against the Kubernetes OpenAPI Schema.
-                    type: boolean
-                  disableWait:
-                    description: DisableWait disables the waiting for resources to be ready after a Helm install has been performed.
-                    type: boolean
-                  remediation:
-                    description: Remediation holds the remediation configuration for when the Helm install action for the HelmRelease fails. The default is to not perform any action.
-                    properties:
-                      ignoreTestFailures:
-                        description: IgnoreTestFailures tells the controller to skip remediation when the Helm tests are run after an install action but fail. Defaults to 'Test.IgnoreFailures'.
-                        type: boolean
-                      remediateLastFailure:
-                        description: RemediateLastFailure tells the controller to remediate the last failure, when no retries remain. Defaults to 'false'.
-                        type: boolean
-                      retries:
-                        description: Retries is the number of retries that should be attempted on failures before bailing. Remediation, using an uninstall, is performed between each attempt. Defaults to '0', a negative integer equals to unlimited retries.
-                        type: integer
-                    type: object
-                  replace:
-                    description: Replace tells the Helm install action to re-use the 'ReleaseName', but only if that name is a deleted release which remains in the history.
-                    type: boolean
-                  skipCRDs:
-                    description: SkipCRDs tells the Helm install action to not install any CRDs. By default, CRDs are installed if not already present.
-                    type: boolean
-                  timeout:
-                    description: Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) during the performance of a Helm install action. Defaults to 'HelmReleaseSpec.Timeout'.
-                    type: string
-                type: object
-              interval:
-                description: Interval at which to reconcile the Helm release.
-                type: string
-              kubeConfig:
-                description: KubeConfig for reconciling the HelmRelease on a remote cluster. When specified, KubeConfig takes precedence over ServiceAccountName.
-                properties:
-                  secretRef:
-                    description: SecretRef holds the name to a secret that contains a 'value' key with the kubeconfig file as the value. It must be in the same namespace as the HelmRelease. It is recommended that the kubeconfig is self-contained, and the secret is regularly updated if credentials such as a cloud-access-token expire. Cloud specific `cmd-path` auth helpers will not function without adding binaries and credentials to the Pod that is responsible for reconciling the HelmRelease.
+                dependsOn:
+                  description: DependsOn may contain a dependency.CrossNamespaceDependencyReference slice with references to HelmRelease resources that must be ready before this HelmRelease can be reconciled.
+                  items:
+                    description: CrossNamespaceDependencyReference holds the reference to a dependency.
                     properties:
                       name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                        description: Name holds the name reference of a dependency.
                         type: string
-                    type: object
-                type: object
-              maxHistory:
-                description: MaxHistory is the number of revisions saved by Helm for this HelmRelease. Use '0' for an unlimited number of revisions; defaults to '10'.
-                type: integer
-              releaseName:
-                description: ReleaseName used for the Helm release. Defaults to a composition of '[TargetNamespace-]Name'.
-                maxLength: 53
-                minLength: 1
-                type: string
-              rollback:
-                description: Rollback holds the configuration for Helm rollback actions for this HelmRelease.
-                properties:
-                  cleanupOnFail:
-                    description: CleanupOnFail allows deletion of new resources created during the Helm rollback action when it fails.
-                    type: boolean
-                  disableHooks:
-                    description: DisableHooks prevents hooks from running during the Helm rollback action.
-                    type: boolean
-                  disableWait:
-                    description: DisableWait disables the waiting for resources to be ready after a Helm rollback has been performed.
-                    type: boolean
-                  force:
-                    description: Force forces resource updates through a replacement strategy.
-                    type: boolean
-                  recreate:
-                    description: Recreate performs pod restarts for the resource if applicable.
-                    type: boolean
-                  timeout:
-                    description: Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) during the performance of a Helm rollback action. Defaults to 'HelmReleaseSpec.Timeout'.
-                    type: string
-                type: object
-              serviceAccountName:
-                description: The name of the Kubernetes service account to impersonate when reconciling this HelmRelease.
-                type: string
-              suspend:
-                description: Suspend tells the controller to suspend reconciliation for this HelmRelease, it does not apply to already started reconciliations. Defaults to false.
-                type: boolean
-              targetNamespace:
-                description: TargetNamespace to target when performing operations for the HelmRelease. Defaults to the namespace of the HelmRelease.
-                maxLength: 63
-                minLength: 1
-                type: string
-              test:
-                description: Test holds the configuration for Helm test actions for this HelmRelease.
-                properties:
-                  enable:
-                    description: Enable enables Helm test actions for this HelmRelease after an Helm install or upgrade action has been performed.
-                    type: boolean
-                  ignoreFailures:
-                    description: IgnoreFailures tells the controller to skip remediation when the Helm tests are run but fail. Can be overwritten for tests run after install or upgrade actions in 'Install.IgnoreTestFailures' and 'Upgrade.IgnoreTestFailures'.
-                    type: boolean
-                  timeout:
-                    description: Timeout is the time to wait for any individual Kubernetes operation during the performance of a Helm test action. Defaults to 'HelmReleaseSpec.Timeout'.
-                    type: string
-                type: object
-              timeout:
-                description: Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) during the performance of a Helm action. Defaults to '5m0s'.
-                type: string
-              uninstall:
-                description: Uninstall holds the configuration for Helm uninstall actions for this HelmRelease.
-                properties:
-                  disableHooks:
-                    description: DisableHooks prevents hooks from running during the Helm rollback action.
-                    type: boolean
-                  keepHistory:
-                    description: KeepHistory tells Helm to remove all associated resources and mark the release as deleted, but retain the release history.
-                    type: boolean
-                  timeout:
-                    description: Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) during the performance of a Helm uninstall action. Defaults to 'HelmReleaseSpec.Timeout'.
-                    type: string
-                type: object
-              upgrade:
-                description: Upgrade holds the configuration for Helm upgrade actions for this HelmRelease.
-                properties:
-                  cleanupOnFail:
-                    description: CleanupOnFail allows deletion of new resources created during the Helm upgrade action when it fails.
-                    type: boolean
-                  disableHooks:
-                    description: DisableHooks prevents hooks from running during the Helm upgrade action.
-                    type: boolean
-                  disableOpenAPIValidation:
-                    description: DisableOpenAPIValidation prevents the Helm upgrade action from validating rendered templates against the Kubernetes OpenAPI Schema.
-                    type: boolean
-                  disableWait:
-                    description: DisableWait disables the waiting for resources to be ready after a Helm upgrade has been performed.
-                    type: boolean
-                  force:
-                    description: Force forces resource updates through a replacement strategy.
-                    type: boolean
-                  preserveValues:
-                    description: PreserveValues will make Helm reuse the last release's values and merge in overrides from 'Values'. Setting this flag makes the HelmRelease non-declarative.
-                    type: boolean
-                  remediation:
-                    description: Remediation holds the remediation configuration for when the Helm upgrade action for the HelmRelease fails. The default is to not perform any action.
-                    properties:
-                      ignoreTestFailures:
-                        description: IgnoreTestFailures tells the controller to skip remediation when the Helm tests are run after an upgrade action but fail. Defaults to 'Test.IgnoreFailures'.
-                        type: boolean
-                      remediateLastFailure:
-                        description: RemediateLastFailure tells the controller to remediate the last failure, when no retries remain. Defaults to 'false' unless 'Retries' is greater than 0.
-                        type: boolean
-                      retries:
-                        description: Retries is the number of retries that should be attempted on failures before bailing. Remediation, using 'Strategy', is performed between each attempt. Defaults to '0', a negative integer equals to unlimited retries.
-                        type: integer
-                      strategy:
-                        description: Strategy to use for failure remediation. Defaults to 'rollback'.
-                        enum:
-                        - rollback
-                        - uninstall
+                      namespace:
+                        description: Namespace holds the namespace reference of a dependency.
                         type: string
+                    required:
+                      - name
                     type: object
-                  timeout:
-                    description: Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) during the performance of a Helm upgrade action. Defaults to 'HelmReleaseSpec.Timeout'.
-                    type: string
-                type: object
-              values:
-                description: Values holds the values for this Helm release.
-                x-kubernetes-preserve-unknown-fields: true
-              valuesFrom:
-                description: ValuesFrom holds references to resources containing Helm values for this HelmRelease, and information about how they should be merged.
-                items:
-                  description: ValuesReference contains a reference to a resource containing Helm values, and optionally the key they can be found at.
+                  type: array
+                install:
+                  description: Install holds the configuration for Helm install actions for this HelmRelease.
                   properties:
-                    kind:
-                      description: Kind of the values referent, valid values are ('Secret', 'ConfigMap').
-                      enum:
-                      - Secret
-                      - ConfigMap
-                      type: string
-                    name:
-                      description: Name of the values referent. Should reside in the same namespace as the referring resource.
-                      maxLength: 253
-                      minLength: 1
-                      type: string
-                    optional:
-                      description: Optional marks this ValuesReference as optional. When set, a not found error for the values reference is ignored, but any ValuesKey, TargetPath or transient error will still result in a reconciliation failure.
+                    createNamespace:
+                      description: CreateNamespace tells the Helm install action to create the HelmReleaseSpec.TargetNamespace if it does not exist yet. On uninstall, the namespace will not be garbage collected.
                       type: boolean
-                    targetPath:
-                      description: TargetPath is the YAML dot notation path the value should be merged at. When set, the ValuesKey is expected to be a single flat value. Defaults to 'None', which results in the values getting merged at the root.
+                    disableHooks:
+                      description: DisableHooks prevents hooks from running during the Helm install action.
+                      type: boolean
+                    disableOpenAPIValidation:
+                      description: DisableOpenAPIValidation prevents the Helm install action from validating rendered templates against the Kubernetes OpenAPI Schema.
+                      type: boolean
+                    disableWait:
+                      description: DisableWait disables the waiting for resources to be ready after a Helm install has been performed.
+                      type: boolean
+                    remediation:
+                      description: Remediation holds the remediation configuration for when the Helm install action for the HelmRelease fails. The default is to not perform any action.
+                      properties:
+                        ignoreTestFailures:
+                          description: IgnoreTestFailures tells the controller to skip remediation when the Helm tests are run after an install action but fail. Defaults to 'Test.IgnoreFailures'.
+                          type: boolean
+                        remediateLastFailure:
+                          description: RemediateLastFailure tells the controller to remediate the last failure, when no retries remain. Defaults to 'false'.
+                          type: boolean
+                        retries:
+                          description: Retries is the number of retries that should be attempted on failures before bailing. Remediation, using an uninstall, is performed between each attempt. Defaults to '0', a negative integer equals to unlimited retries.
+                          type: integer
+                      type: object
+                    replace:
+                      description: Replace tells the Helm install action to re-use the 'ReleaseName', but only if that name is a deleted release which remains in the history.
+                      type: boolean
+                    skipCRDs:
+                      description: SkipCRDs tells the Helm install action to not install any CRDs. By default, CRDs are installed if not already present.
+                      type: boolean
+                    timeout:
+                      description: Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) during the performance of a Helm install action. Defaults to 'HelmReleaseSpec.Timeout'.
                       type: string
-                    valuesKey:
-                      description: ValuesKey is the data key where the values.yaml or a specific value can be found at. Defaults to 'values.yaml'.
-                      type: string
-                  required:
-                  - kind
-                  - name
                   type: object
-                type: array
-            required:
-            - chart
-            - interval
-            type: object
-          status:
-            description: HelmReleaseStatus defines the observed state of a HelmRelease.
-            properties:
-              conditions:
-                description: Conditions holds the conditions for the HelmRelease.
-                items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                interval:
+                  description: Interval at which to reconcile the Helm release.
+                  type: string
+                kubeConfig:
+                  description: KubeConfig for reconciling the HelmRelease on a remote cluster. When specified, KubeConfig takes precedence over ServiceAccountName.
                   properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human readable message indicating details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    secretRef:
+                      description: SecretRef holds the name to a secret that contains a 'value' key with the kubeconfig file as the value. It must be in the same namespace as the HelmRelease. It is recommended that the kubeconfig is self-contained, and the secret is regularly updated if credentials such as a cloud-access-token expire. Cloud specific `cmd-path` auth helpers will not function without adding binaries and credentials to the Pod that is responsible for reconciling the HelmRelease.
+                      properties:
+                        name:
+                          description: Name of the referent
+                          type: string
+                      required:
+                        - name
+                      type: object
                   type: object
-                type: array
-              failures:
-                description: Failures is the reconciliation failure count against the latest desired state. It is reset after a successful reconciliation.
-                format: int64
-                type: integer
-              helmChart:
-                description: HelmChart is the namespaced name of the HelmChart resource created by the controller for the HelmRelease.
-                type: string
-              installFailures:
-                description: InstallFailures is the install failure count against the latest desired state. It is reset after a successful reconciliation.
-                format: int64
-                type: integer
-              lastAppliedRevision:
-                description: LastAppliedRevision is the revision of the last successfully applied source.
-                type: string
-              lastAttemptedRevision:
-                description: LastAttemptedRevision is the revision of the last reconciliation attempt.
-                type: string
-              lastAttemptedValuesChecksum:
-                description: LastAttemptedValuesChecksum is the SHA1 checksum of the values of the last reconciliation attempt.
-                type: string
-              lastHandledReconcileAt:
-                description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change can be detected.
-                type: string
-              lastReleaseRevision:
-                description: LastReleaseRevision is the revision of the last successful Helm release.
-                type: integer
-              observedGeneration:
-                description: ObservedGeneration is the last observed generation.
-                format: int64
-                type: integer
-              upgradeFailures:
-                description: UpgradeFailures is the upgrade failure count against the latest desired state. It is reset after a successful reconciliation.
-                format: int64
-                type: integer
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                maxHistory:
+                  description: MaxHistory is the number of revisions saved by Helm for this HelmRelease. Use '0' for an unlimited number of revisions; defaults to '10'.
+                  type: integer
+                releaseName:
+                  description: ReleaseName used for the Helm release. Defaults to a composition of '[TargetNamespace-]Name'.
+                  maxLength: 53
+                  minLength: 1
+                  type: string
+                rollback:
+                  description: Rollback holds the configuration for Helm rollback actions for this HelmRelease.
+                  properties:
+                    cleanupOnFail:
+                      description: CleanupOnFail allows deletion of new resources created during the Helm rollback action when it fails.
+                      type: boolean
+                    disableHooks:
+                      description: DisableHooks prevents hooks from running during the Helm rollback action.
+                      type: boolean
+                    disableWait:
+                      description: DisableWait disables the waiting for resources to be ready after a Helm rollback has been performed.
+                      type: boolean
+                    force:
+                      description: Force forces resource updates through a replacement strategy.
+                      type: boolean
+                    recreate:
+                      description: Recreate performs pod restarts for the resource if applicable.
+                      type: boolean
+                    timeout:
+                      description: Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) during the performance of a Helm rollback action. Defaults to 'HelmReleaseSpec.Timeout'.
+                      type: string
+                  type: object
+                serviceAccountName:
+                  description: The name of the Kubernetes service account to impersonate when reconciling this HelmRelease.
+                  type: string
+                storageNamespace:
+                  description: StorageNamespace used for the Helm storage. Defaults to the namespace of the HelmRelease.
+                  maxLength: 63
+                  minLength: 1
+                  type: string
+                suspend:
+                  description: Suspend tells the controller to suspend reconciliation for this HelmRelease, it does not apply to already started reconciliations. Defaults to false.
+                  type: boolean
+                targetNamespace:
+                  description: TargetNamespace to target when performing operations for the HelmRelease. Defaults to the namespace of the HelmRelease.
+                  maxLength: 63
+                  minLength: 1
+                  type: string
+                test:
+                  description: Test holds the configuration for Helm test actions for this HelmRelease.
+                  properties:
+                    enable:
+                      description: Enable enables Helm test actions for this HelmRelease after an Helm install or upgrade action has been performed.
+                      type: boolean
+                    ignoreFailures:
+                      description: IgnoreFailures tells the controller to skip remediation when the Helm tests are run but fail. Can be overwritten for tests run after install or upgrade actions in 'Install.IgnoreTestFailures' and 'Upgrade.IgnoreTestFailures'.
+                      type: boolean
+                    timeout:
+                      description: Timeout is the time to wait for any individual Kubernetes operation during the performance of a Helm test action. Defaults to 'HelmReleaseSpec.Timeout'.
+                      type: string
+                  type: object
+                timeout:
+                  description: Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) during the performance of a Helm action. Defaults to '5m0s'.
+                  type: string
+                uninstall:
+                  description: Uninstall holds the configuration for Helm uninstall actions for this HelmRelease.
+                  properties:
+                    disableHooks:
+                      description: DisableHooks prevents hooks from running during the Helm rollback action.
+                      type: boolean
+                    keepHistory:
+                      description: KeepHistory tells Helm to remove all associated resources and mark the release as deleted, but retain the release history.
+                      type: boolean
+                    timeout:
+                      description: Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) during the performance of a Helm uninstall action. Defaults to 'HelmReleaseSpec.Timeout'.
+                      type: string
+                  type: object
+                upgrade:
+                  description: Upgrade holds the configuration for Helm upgrade actions for this HelmRelease.
+                  properties:
+                    cleanupOnFail:
+                      description: CleanupOnFail allows deletion of new resources created during the Helm upgrade action when it fails.
+                      type: boolean
+                    disableHooks:
+                      description: DisableHooks prevents hooks from running during the Helm upgrade action.
+                      type: boolean
+                    disableOpenAPIValidation:
+                      description: DisableOpenAPIValidation prevents the Helm upgrade action from validating rendered templates against the Kubernetes OpenAPI Schema.
+                      type: boolean
+                    disableWait:
+                      description: DisableWait disables the waiting for resources to be ready after a Helm upgrade has been performed.
+                      type: boolean
+                    force:
+                      description: Force forces resource updates through a replacement strategy.
+                      type: boolean
+                    preserveValues:
+                      description: PreserveValues will make Helm reuse the last release's values and merge in overrides from 'Values'. Setting this flag makes the HelmRelease non-declarative.
+                      type: boolean
+                    remediation:
+                      description: Remediation holds the remediation configuration for when the Helm upgrade action for the HelmRelease fails. The default is to not perform any action.
+                      properties:
+                        ignoreTestFailures:
+                          description: IgnoreTestFailures tells the controller to skip remediation when the Helm tests are run after an upgrade action but fail. Defaults to 'Test.IgnoreFailures'.
+                          type: boolean
+                        remediateLastFailure:
+                          description: RemediateLastFailure tells the controller to remediate the last failure, when no retries remain. Defaults to 'false' unless 'Retries' is greater than 0.
+                          type: boolean
+                        retries:
+                          description: Retries is the number of retries that should be attempted on failures before bailing. Remediation, using 'Strategy', is performed between each attempt. Defaults to '0', a negative integer equals to unlimited retries.
+                          type: integer
+                        strategy:
+                          description: Strategy to use for failure remediation. Defaults to 'rollback'.
+                          enum:
+                            - rollback
+                            - uninstall
+                          type: string
+                      type: object
+                    timeout:
+                      description: Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) during the performance of a Helm upgrade action. Defaults to 'HelmReleaseSpec.Timeout'.
+                      type: string
+                  type: object
+                values:
+                  description: Values holds the values for this Helm release.
+                  x-kubernetes-preserve-unknown-fields: true
+                valuesFrom:
+                  description: ValuesFrom holds references to resources containing Helm values for this HelmRelease, and information about how they should be merged.
+                  items:
+                    description: ValuesReference contains a reference to a resource containing Helm values, and optionally the key they can be found at.
+                    properties:
+                      kind:
+                        description: Kind of the values referent, valid values are ('Secret', 'ConfigMap').
+                        enum:
+                          - Secret
+                          - ConfigMap
+                        type: string
+                      name:
+                        description: Name of the values referent. Should reside in the same namespace as the referring resource.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      optional:
+                        description: Optional marks this ValuesReference as optional. When set, a not found error for the values reference is ignored, but any ValuesKey, TargetPath or transient error will still result in a reconciliation failure.
+                        type: boolean
+                      targetPath:
+                        description: TargetPath is the YAML dot notation path the value should be merged at. When set, the ValuesKey is expected to be a single flat value. Defaults to 'None', which results in the values getting merged at the root.
+                        type: string
+                      valuesKey:
+                        description: ValuesKey is the data key where the values.yaml or a specific value can be found at. Defaults to 'values.yaml'.
+                        type: string
+                    required:
+                      - kind
+                      - name
+                    type: object
+                  type: array
+              required:
+                - chart
+                - interval
+              type: object
+            status:
+              description: HelmReleaseStatus defines the observed state of a HelmRelease.
+              properties:
+                conditions:
+                  description: Conditions holds the conditions for the HelmRelease.
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                failures:
+                  description: Failures is the reconciliation failure count against the latest desired state. It is reset after a successful reconciliation.
+                  format: int64
+                  type: integer
+                helmChart:
+                  description: HelmChart is the namespaced name of the HelmChart resource created by the controller for the HelmRelease.
+                  type: string
+                installFailures:
+                  description: InstallFailures is the install failure count against the latest desired state. It is reset after a successful reconciliation.
+                  format: int64
+                  type: integer
+                lastAppliedRevision:
+                  description: LastAppliedRevision is the revision of the last successfully applied source.
+                  type: string
+                lastAttemptedRevision:
+                  description: LastAttemptedRevision is the revision of the last reconciliation attempt.
+                  type: string
+                lastAttemptedValuesChecksum:
+                  description: LastAttemptedValuesChecksum is the SHA1 checksum of the values of the last reconciliation attempt.
+                  type: string
+                lastHandledReconcileAt:
+                  description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change can be detected.
+                  type: string
+                lastReleaseRevision:
+                  description: LastReleaseRevision is the revision of the last successful Helm release.
+                  type: integer
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation.
+                  format: int64
+                  type: integer
+                upgradeFailures:
+                  description: UpgradeFailures is the upgrade failure count against the latest desired state. It is reset after a successful reconciliation.
+                  format: int64
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/helm/flux-app/crds/helmrepository.yaml
+++ b/helm/flux-app/crds/helmrepository.yaml
@@ -16,145 +16,147 @@ spec:
     singular: helmrepository
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.url
-      name: URL
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: HelmRepository is the Schema for the helmrepositories API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: HelmRepositorySpec defines the reference to a Helm repository.
-            properties:
-              interval:
-                description: The interval at which to check the upstream for updates.
-                type: string
-              secretRef:
-                description: The name of the secret containing authentication credentials for the Helm repository. For HTTP/S basic auth the secret must contain username and password fields. For TLS the secret must contain a certFile and keyFile, and/or caCert fields.
-                properties:
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                    type: string
-                type: object
-              suspend:
-                description: This flag tells the controller to suspend the reconciliation of this source.
-                type: boolean
-              timeout:
-                default: 60s
-                description: The timeout of index downloading, defaults to 60s.
-                type: string
-              url:
-                description: The Helm repository URL, a valid URL contains at least a protocol and host.
-                type: string
-            required:
-            - interval
-            - url
-            type: object
-          status:
-            description: HelmRepositoryStatus defines the observed state of the HelmRepository.
-            properties:
-              artifact:
-                description: Artifact represents the output of the last successful repository sync.
-                properties:
-                  checksum:
-                    description: Checksum is the SHA1 checksum of the artifact.
-                    type: string
-                  lastUpdateTime:
-                    description: LastUpdateTime is the timestamp corresponding to the last update of this artifact.
-                    format: date-time
-                    type: string
-                  path:
-                    description: Path is the relative file path of this artifact.
-                    type: string
-                  revision:
-                    description: Revision is a human readable identifier traceable in the origin source system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm chart version, etc.
-                    type: string
-                  url:
-                    description: URL is the HTTP address of this artifact.
-                    type: string
-                required:
-                - path
-                - url
-                type: object
-              conditions:
-                description: Conditions holds the conditions for the HelmRepository.
-                items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+    - additionalPrinterColumns:
+        - jsonPath: .spec.url
+          name: URL
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: HelmRepository is the Schema for the helmrepositories API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: HelmRepositorySpec defines the reference to a Helm repository.
+              properties:
+                interval:
+                  description: The interval at which to check the upstream for updates.
+                  type: string
+                secretRef:
+                  description: The name of the secret containing authentication credentials for the Helm repository. For HTTP/S basic auth the secret must contain username and password fields. For TLS the secret must contain a certFile and keyFile, and/or caCert fields.
                   properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human readable message indicating details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    name:
+                      description: Name of the referent
                       type: string
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    - name
                   type: object
-                type: array
-              lastHandledReconcileAt:
-                description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change can be detected.
-                type: string
-              observedGeneration:
-                description: ObservedGeneration is the last observed generation.
-                format: int64
-                type: integer
-              url:
-                description: URL is the download link for the last index fetched.
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                suspend:
+                  description: This flag tells the controller to suspend the reconciliation of this source.
+                  type: boolean
+                timeout:
+                  default: 60s
+                  description: The timeout of index downloading, defaults to 60s.
+                  type: string
+                url:
+                  description: The Helm repository URL, a valid URL contains at least a protocol and host.
+                  type: string
+              required:
+                - interval
+                - url
+              type: object
+            status:
+              description: HelmRepositoryStatus defines the observed state of the HelmRepository.
+              properties:
+                artifact:
+                  description: Artifact represents the output of the last successful repository sync.
+                  properties:
+                    checksum:
+                      description: Checksum is the SHA1 checksum of the artifact.
+                      type: string
+                    lastUpdateTime:
+                      description: LastUpdateTime is the timestamp corresponding to the last update of this artifact.
+                      format: date-time
+                      type: string
+                    path:
+                      description: Path is the relative file path of this artifact.
+                      type: string
+                    revision:
+                      description: Revision is a human readable identifier traceable in the origin source system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm chart version, etc.
+                      type: string
+                    url:
+                      description: URL is the HTTP address of this artifact.
+                      type: string
+                  required:
+                    - path
+                    - url
+                  type: object
+                conditions:
+                  description: Conditions holds the conditions for the HelmRepository.
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                lastHandledReconcileAt:
+                  description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change can be detected.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation.
+                  format: int64
+                  type: integer
+                url:
+                  description: URL is the download link for the last index fetched.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/helm/flux-app/crds/imagepolicy.yaml
+++ b/helm/flux-app/crds/imagepolicy.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -16,119 +16,131 @@ spec:
     singular: imagepolicy
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.latestImage
-      name: LatestImage
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: ImagePolicy is the Schema for the imagepolicies API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ImagePolicySpec defines the parameters for calculating the ImagePolicy
-            properties:
-              imageRepositoryRef:
-                description: ImageRepositoryRef points at the object specifying the image being scanned
-                properties:
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                    type: string
-                type: object
-              policy:
-                description: Policy gives the particulars of the policy to be followed in selecting the most recent image
-                properties:
-                  alphabetical:
-                    description: Alphabetical set of rules to use for alphabetical ordering of the tags.
-                    properties:
-                      order:
-                        default: asc
-                        description: Order specifies the sorting order of the tags. Given the letters of the alphabet as tags, ascending order would select Z, and descending order would select A.
-                        enum:
-                        - asc
-                        - desc
-                        type: string
-                    type: object
-                  semver:
-                    description: SemVer gives a semantic version range to check against the tags available.
-                    properties:
-                      range:
-                        description: Range gives a semver range for the image tag; the highest version within the range that's a tag yields the latest image.
-                        type: string
-                    required:
-                    - range
-                    type: object
-                type: object
-            required:
-            - imageRepositoryRef
-            - policy
-            type: object
-          status:
-            description: ImagePolicyStatus defines the observed state of ImagePolicy
-            properties:
-              conditions:
-                items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+    - additionalPrinterColumns:
+        - jsonPath: .status.latestImage
+          name: LatestImage
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ImagePolicy is the Schema for the imagepolicies API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ImagePolicySpec defines the parameters for calculating the ImagePolicy
+              properties:
+                filterTags:
+                  description: FilterTags enables filtering for only a subset of tags based on a set of rules. If no rules are provided, all the tags from the repository will be ordered and compared.
                   properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
+                    extract:
+                      description: Extract allows a capture group to be extracted from the specified regular expression pattern, useful before tag evaluation.
                       type: string
-                    message:
-                      description: message is a human readable message indicating details about the transition. This may be an empty string.
-                      maxLength: 32768
+                    pattern:
+                      description: Pattern specifies a regular expression pattern used to filter for image tags.
                       type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                  type: object
+                imageRepositoryRef:
+                  description: ImageRepositoryRef points at the object specifying the image being scanned
+                  properties:
+                    name:
+                      description: Name of the referent
                       type: string
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    - name
                   type: object
-                type: array
-              latestImage:
-                description: LatestImage gives the first in the list of images scanned by the image repository, when filtered and ordered according to the policy.
-                type: string
-              observedGeneration:
-                format: int64
-                type: integer
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                policy:
+                  description: Policy gives the particulars of the policy to be followed in selecting the most recent image
+                  properties:
+                    alphabetical:
+                      description: Alphabetical set of rules to use for alphabetical ordering of the tags.
+                      properties:
+                        order:
+                          default: asc
+                          description: Order specifies the sorting order of the tags. Given the letters of the alphabet as tags, ascending order would select Z, and descending order would select A.
+                          enum:
+                            - asc
+                            - desc
+                          type: string
+                      type: object
+                    semver:
+                      description: SemVer gives a semantic version range to check against the tags available.
+                      properties:
+                        range:
+                          description: Range gives a semver range for the image tag; the highest version within the range that's a tag yields the latest image.
+                          type: string
+                      required:
+                        - range
+                      type: object
+                  type: object
+              required:
+                - imageRepositoryRef
+                - policy
+              type: object
+            status:
+              description: ImagePolicyStatus defines the observed state of ImagePolicy
+              properties:
+                conditions:
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                latestImage:
+                  description: LatestImage gives the first in the list of images scanned by the image repository, when filtered and ordered according to the policy.
+                  type: string
+                observedGeneration:
+                  format: int64
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/helm/flux-app/crds/imagerepository.yaml
+++ b/helm/flux-app/crds/imagerepository.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: flux-system
@@ -16,122 +16,133 @@ spec:
     singular: imagerepository
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.lastScanTime
-      name: Last scan
-      type: string
-    - jsonPath: .status.lastScanResult.tagCount
-      name: Tags
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: ImageRepository is the Schema for the imagerepositories API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ImageRepositorySpec defines the parameters for scanning an image repository, e.g., `fluxcd/flux`.
-            properties:
-              image:
-                description: Image is the name of the image repository
-                type: string
-              interval:
-                description: Interval is the length of time to wait between scans of the image repository.
-                type: string
-              secretRef:
-                description: SecretRef can be given the name of a secret containing credentials to use for the image registry. The secret should be created with `kubectl create secret docker-registry`, or the equivalent.
-                properties:
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                    type: string
-                type: object
-              suspend:
-                description: This flag tells the controller to suspend subsequent image scans. It does not apply to already started scans. Defaults to false.
-                type: boolean
-              timeout:
-                description: Timeout for image scanning. Defaults to 'Interval' duration.
-                type: string
-            type: object
-          status:
-            description: ImageRepositoryStatus defines the observed state of ImageRepository
-            properties:
-              canonicalImageName:
-                description: CannonicalName is the name of the image repository with all the implied bits made explicit; e.g., `docker.io/library/alpine` rather than `alpine`.
-                type: string
-              conditions:
-                items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+    - additionalPrinterColumns:
+        - jsonPath: .status.lastScanTime
+          name: Last scan
+          type: string
+        - jsonPath: .status.lastScanResult.tagCount
+          name: Tags
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ImageRepository is the Schema for the imagerepositories API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ImageRepositorySpec defines the parameters for scanning an image repository, e.g., `fluxcd/flux`.
+              properties:
+                certSecretRef:
+                  description: "CertSecretRef can be given the name of a secret containing either or both of \n  - a PEM-encoded client certificate (`certFile`) and private  key (`keyFile`);  - a PEM-encoded CA certificate (`caFile`) \n  and whichever are supplied, will be used for connecting to the  registry. The client cert and key are useful if you are  authenticating with a certificate; the CA cert is useful if  you are using a self-signed server certificate."
                   properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human readable message indicating details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    name:
+                      description: Name of the referent
                       type: string
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    - name
                   type: object
-                type: array
-              lastHandledReconcileAt:
-                description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change can be detected.
-                type: string
-              lastScanResult:
-                description: LastScanResult contains the number of fetched tags.
-                properties:
-                  scanTime:
-                    format: date-time
-                    type: string
-                  tagCount:
-                    type: integer
-                required:
-                - tagCount
-                type: object
-              observedGeneration:
-                description: ObservedGeneration is the last reconciled generation.
-                format: int64
-                type: integer
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                image:
+                  description: Image is the name of the image repository
+                  type: string
+                interval:
+                  description: Interval is the length of time to wait between scans of the image repository.
+                  type: string
+                secretRef:
+                  description: SecretRef can be given the name of a secret containing credentials to use for the image registry. The secret should be created with `kubectl create secret docker-registry`, or the equivalent.
+                  properties:
+                    name:
+                      description: Name of the referent
+                      type: string
+                  required:
+                    - name
+                  type: object
+                suspend:
+                  description: This flag tells the controller to suspend subsequent image scans. It does not apply to already started scans. Defaults to false.
+                  type: boolean
+                timeout:
+                  description: Timeout for image scanning. Defaults to 'Interval' duration.
+                  type: string
+              type: object
+            status:
+              description: ImageRepositoryStatus defines the observed state of ImageRepository
+              properties:
+                canonicalImageName:
+                  description: CanonicalName is the name of the image repository with all the implied bits made explicit; e.g., `docker.io/library/alpine` rather than `alpine`.
+                  type: string
+                conditions:
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                lastHandledReconcileAt:
+                  description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change can be detected.
+                  type: string
+                lastScanResult:
+                  description: LastScanResult contains the number of fetched tags.
+                  properties:
+                    scanTime:
+                      format: date-time
+                      type: string
+                    tagCount:
+                      type: integer
+                  required:
+                    - tagCount
+                  type: object
+                observedGeneration:
+                  description: ObservedGeneration is the last reconciled generation.
+                  format: int64
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/helm/flux-app/crds/imageupdateautomation.yaml
+++ b/helm/flux-app/crds/imageupdateautomation.yaml
@@ -16,147 +16,155 @@ spec:
     singular: imageupdateautomation
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.lastAutomationRunTime
-      name: Last run
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: ImageUpdateAutomation is the Schema for the imageupdateautomations API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ImageUpdateAutomationSpec defines the desired state of ImageUpdateAutomation
-            properties:
-              checkout:
-                description: Checkout gives the parameters for cloning the git repository, ready to make changes.
-                properties:
-                  branch:
-                    description: Branch gives the branch to clone from the git repository.
-                    type: string
-                  gitRepositoryRef:
-                    description: GitRepositoryRef refers to the resource giving access details to a git repository to update files in.
-                    properties:
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                        type: string
-                    type: object
-                required:
-                - branch
-                - gitRepositoryRef
-                type: object
-              commit:
-                description: Commit specifies how to commit to the git repo
-                properties:
-                  authorEmail:
-                    description: AuthorEmail gives the email to provide when making a commit
-                    type: string
-                  authorName:
-                    description: AuthorName gives the name to provide when making a commit
-                    type: string
-                  messageTemplate:
-                    description: MessageTemplate provides a template for the commit message, into which will be interpolated the details of the change made.
-                    type: string
-                required:
-                - authorEmail
-                - authorName
-                type: object
-              interval:
-                description: Interval gives an lower bound for how often the automation run should be attempted.
-                type: string
-              suspend:
-                description: Suspend tells the controller to not run this automation, until it is unset (or set to false). Defaults to false.
-                type: boolean
-              update:
-                description: Update gives the specification for how to update the files in the repository
-                properties:
-                  setters:
-                    description: Setters if present means update workloads using setters, via fields marked in the files themselves.
-                    type: object
-                type: object
-            required:
-            - checkout
-            - commit
-            - interval
-            - update
-            type: object
-          status:
-            description: ImageUpdateAutomationStatus defines the observed state of ImageUpdateAutomation
-            properties:
-              conditions:
-                items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+    - additionalPrinterColumns:
+        - jsonPath: .status.lastAutomationRunTime
+          name: Last run
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ImageUpdateAutomation is the Schema for the imageupdateautomations API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ImageUpdateAutomationSpec defines the desired state of ImageUpdateAutomation
+              properties:
+                checkout:
+                  description: Checkout gives the parameters for cloning the git repository, ready to make changes.
                   properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
+                    branch:
+                      description: Branch gives the branch to clone from the git repository.
                       type: string
-                    message:
-                      description: message is a human readable message indicating details about the transition. This may be an empty string.
-                      maxLength: 32768
+                    gitRepositoryRef:
+                      description: GitRepositoryRef refers to the resource giving access details to a git repository to update files in.
+                      properties:
+                        name:
+                          description: Name of the referent
+                          type: string
+                      required:
+                        - name
+                      type: object
+                  required:
+                    - branch
+                    - gitRepositoryRef
+                  type: object
+                commit:
+                  description: Commit specifies how to commit to the git repo
+                  properties:
+                    authorEmail:
+                      description: AuthorEmail gives the email to provide when making a commit
                       type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                    authorName:
+                      description: AuthorName gives the name to provide when making a commit
                       type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    messageTemplate:
+                      description: MessageTemplate provides a template for the commit message, into which will be interpolated the details of the change made.
                       type: string
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    - authorEmail
+                    - authorName
                   type: object
-                type: array
-              lastAutomationRunTime:
-                description: LastAutomationRunTime records the last time the controller ran this automation through to completion (even if no updates were made).
-                format: date-time
-                type: string
-              lastHandledReconcileAt:
-                description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change can be detected.
-                type: string
-              lastPushCommit:
-                description: LastPushCommit records the SHA1 of the last commit made by the controller, for this automation object
-                type: string
-              lastPushTime:
-                description: LastPushTime records the time of the last pushed change.
-                format: date-time
-                type: string
-              observedGeneration:
-                format: int64
-                type: integer
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                interval:
+                  description: Interval gives an lower bound for how often the automation run should be attempted.
+                  type: string
+                suspend:
+                  description: Suspend tells the controller to not run this automation, until it is unset (or set to false). Defaults to false.
+                  type: boolean
+                update:
+                  default:
+                    strategy: Setters
+                  description: Update gives the specification for how to update the files in the repository. This can be left empty, to use the default value.
+                  properties:
+                    strategy:
+                      default: Setters
+                      description: Strategy names the strategy to be used.
+                      enum:
+                        - Setters
+                      type: string
+                  required:
+                    - strategy
+                  type: object
+              required:
+                - checkout
+                - commit
+                - interval
+              type: object
+            status:
+              description: ImageUpdateAutomationStatus defines the observed state of ImageUpdateAutomation
+              properties:
+                conditions:
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                lastAutomationRunTime:
+                  description: LastAutomationRunTime records the last time the controller ran this automation through to completion (even if no updates were made).
+                  format: date-time
+                  type: string
+                lastHandledReconcileAt:
+                  description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change can be detected.
+                  type: string
+                lastPushCommit:
+                  description: LastPushCommit records the SHA1 of the last commit made by the controller, for this automation object
+                  type: string
+                lastPushTime:
+                  description: LastPushTime records the time of the last pushed change.
+                  format: date-time
+                  type: string
+                observedGeneration:
+                  format: int64
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/helm/flux-app/crds/kustomization.yaml
+++ b/helm/flux-app/crds/kustomization.yaml
@@ -14,271 +14,278 @@ spec:
     listKind: KustomizationList
     plural: kustomizations
     shortNames:
-    - ks
+      - ks
     singular: kustomization
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: Kustomization is the Schema for the kustomizations API.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: KustomizationSpec defines the desired state of a kustomization.
-            properties:
-              decryption:
-                description: Decrypt Kubernetes secrets before applying them on the cluster.
-                properties:
-                  provider:
-                    description: Provider is the name of the decryption engine.
-                    enum:
-                    - sops
-                    type: string
-                  secretRef:
-                    description: The secret name containing the private OpenPGP keys used for decryption.
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: Kustomization is the Schema for the kustomizations API.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: KustomizationSpec defines the desired state of a kustomization.
+              properties:
+                decryption:
+                  description: Decrypt Kubernetes secrets before applying them on the cluster.
+                  properties:
+                    provider:
+                      description: Provider is the name of the decryption engine.
+                      enum:
+                        - sops
+                      type: string
+                    secretRef:
+                      description: The secret name containing the private OpenPGP keys used for decryption.
+                      properties:
+                        name:
+                          description: Name of the referent
+                          type: string
+                      required:
+                        - name
+                      type: object
+                  required:
+                    - provider
+                  type: object
+                dependsOn:
+                  description: DependsOn may contain a dependency.CrossNamespaceDependencyReference slice with references to Kustomization resources that must be ready before this Kustomization can be reconciled.
+                  items:
+                    description: CrossNamespaceDependencyReference holds the reference to a dependency.
                     properties:
                       name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                        description: Name holds the name reference of a dependency.
                         type: string
+                      namespace:
+                        description: Namespace holds the namespace reference of a dependency.
+                        type: string
+                    required:
+                      - name
                     type: object
-                required:
-                - provider
-                type: object
-              dependsOn:
-                description: DependsOn may contain a dependency.CrossNamespaceDependencyReference slice with references to Kustomization resources that must be ready before this Kustomization can be reconciled.
-                items:
-                  description: CrossNamespaceDependencyReference holds the reference to a dependency.
+                  type: array
+                healthChecks:
+                  description: A list of resources to be included in the health assessment.
+                  items:
+                    description: NamespacedObjectKindReference contains enough information to let you locate the typed referenced object in any namespace
+                    properties:
+                      apiVersion:
+                        description: API version of the referent, if not specified the Kubernetes preferred version will be used
+                        type: string
+                      kind:
+                        description: Kind of the referent
+                        type: string
+                      name:
+                        description: Name of the referent
+                        type: string
+                      namespace:
+                        description: Namespace of the referent, when not specified it acts as LocalObjectReference
+                        type: string
+                    required:
+                      - kind
+                      - name
+                    type: object
+                  type: array
+                images:
+                  description: A list of images used to override or set the name and tag for container images.
+                  items:
+                    description: Image contains the name, new name and new tag that will replace the original container image.
+                    properties:
+                      name:
+                        description: Name of the image to be replaced.
+                        type: string
+                      newName:
+                        description: NewName is the name of the image used to replace the original one.
+                        type: string
+                      newTag:
+                        description: NewTag is the image tag used to replace the original tag.
+                        type: string
+                    required:
+                      - name
+                      - newName
+                      - newTag
+                    type: object
+                  type: array
+                interval:
+                  description: The interval at which to reconcile the Kustomization.
+                  type: string
+                kubeConfig:
+                  description: The KubeConfig for reconciling the Kustomization on a remote cluster. When specified, KubeConfig takes precedence over ServiceAccountName.
                   properties:
-                    name:
-                      description: Name holds the name reference of a dependency.
-                      type: string
-                    namespace:
-                      description: Namespace holds the namespace reference of a dependency.
-                      type: string
-                  required:
-                  - name
+                    secretRef:
+                      description: SecretRef holds the name to a secret that contains a 'value' key with the kubeconfig file as the value. It must be in the same namespace as the Kustomization. It is recommended that the kubeconfig is self-contained, and the secret is regularly updated if credentials such as a cloud-access-token expire. Cloud specific `cmd-path` auth helpers will not function without adding binaries and credentials to the Pod that is responsible for reconciling the Kustomization.
+                      properties:
+                        name:
+                          description: Name of the referent
+                          type: string
+                      required:
+                        - name
+                      type: object
                   type: object
-                type: array
-              healthChecks:
-                description: A list of resources to be included in the health assessment.
-                items:
-                  description: CrossNamespaceObjectReference contains enough information to let you locate the typed referenced object at cluster level
+                path:
+                  description: Path to the directory containing the kustomization.yaml file, or the set of plain YAMLs a kustomization.yaml should be generated for. Defaults to 'None', which translates to the root path of the SourceRef.
+                  type: string
+                prune:
+                  description: Prune enables garbage collection.
+                  type: boolean
+                retryInterval:
+                  description: The interval at which to retry a previously failed reconciliation. When not specified, the controller uses the KustomizationSpec.Interval value to retry failures.
+                  type: string
+                serviceAccountName:
+                  description: The name of the Kubernetes service account to impersonate when reconciling this Kustomization.
+                  type: string
+                sourceRef:
+                  description: Reference of the source where the kustomization file is.
                   properties:
                     apiVersion:
-                      description: API version of the referent, defaults to 'apps/v1'
+                      description: API version of the referent
                       type: string
                     kind:
                       description: Kind of the referent
+                      enum:
+                        - GitRepository
+                        - Bucket
                       type: string
                     name:
                       description: Name of the referent
                       type: string
                     namespace:
-                      description: Namespace of the referent
+                      description: Namespace of the referent, defaults to the Kustomization namespace
                       type: string
                   required:
-                  - kind
-                  - name
+                    - kind
+                    - name
                   type: object
-                type: array
-              images:
-                description: A list of images used to override or set the name and tag for container images.
-                items:
-                  description: Image contains the name, new name and new tag that will replace the original container image.
-                  properties:
-                    name:
-                      description: Name of the image to be replaced.
-                      type: string
-                    newName:
-                      description: NewName is the name of the image used to replace the original one.
-                      type: string
-                    newTag:
-                      description: NewTag is the image tag used to replace the original tag.
-                      type: string
-                  required:
-                  - name
-                  - newName
-                  - newTag
-                  type: object
-                type: array
-              interval:
-                description: The interval at which to reconcile the Kustomization.
-                type: string
-              kubeConfig:
-                description: The KubeConfig for reconciling the Kustomization on a remote cluster. When specified, KubeConfig takes precedence over ServiceAccountName.
-                properties:
-                  secretRef:
-                    description: SecretRef holds the name to a secret that contains a 'value' key with the kubeconfig file as the value. It must be in the same namespace as the Kustomization. It is recommended that the kubeconfig is self-contained, and the secret is regularly updated if credentials such as a cloud-access-token expire. Cloud specific `cmd-path` auth helpers will not function without adding binaries and credentials to the Pod that is responsible for reconciling the Kustomization.
+                suspend:
+                  description: This flag tells the controller to suspend subsequent kustomize executions, it does not apply to already started executions. Defaults to false.
+                  type: boolean
+                targetNamespace:
+                  description: TargetNamespace sets or overrides the namespace in the kustomization.yaml file.
+                  maxLength: 63
+                  minLength: 1
+                  type: string
+                timeout:
+                  description: Timeout for validation, apply and health checking operations. Defaults to 'Interval' duration.
+                  type: string
+                validation:
+                  description: Validate the Kubernetes objects before applying them on the cluster. The validation strategy can be 'client' (local dry-run), 'server' (APIServer dry-run) or 'none'.
+                  enum:
+                    - none
+                    - client
+                    - server
+                  type: string
+              required:
+                - interval
+                - prune
+                - sourceRef
+              type: object
+            status:
+              description: KustomizationStatus defines the observed state of a kustomization.
+              properties:
+                conditions:
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
                     properties:
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
                         type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
                     type: object
-                type: object
-              path:
-                description: Path to the directory containing the kustomization.yaml file, or the set of plain YAMLs a kustomization.yaml should be generated for. Defaults to 'None', which translates to the root path of the SourceRef.
-                type: string
-              prune:
-                description: Prune enables garbage collection.
-                type: boolean
-              serviceAccountName:
-                description: The name of the Kubernetes service account to impersonate when reconciling this Kustomization.
-                type: string
-              sourceRef:
-                description: Reference of the source where the kustomization file is.
-                properties:
-                  apiVersion:
-                    description: API version of the referent
-                    type: string
-                  kind:
-                    description: Kind of the referent
-                    enum:
-                    - GitRepository
-                    - Bucket
-                    type: string
-                  name:
-                    description: Name of the referent
-                    type: string
-                  namespace:
-                    description: Namespace of the referent, defaults to the Kustomization namespace
-                    type: string
-                required:
-                - kind
-                - name
-                type: object
-              suspend:
-                description: This flag tells the controller to suspend subsequent kustomize executions, it does not apply to already started executions. Defaults to false.
-                type: boolean
-              targetNamespace:
-                description: TargetNamespace sets or overrides the namespace in the kustomization.yaml file.
-                maxLength: 63
-                minLength: 1
-                type: string
-              timeout:
-                description: Timeout for validation, apply and health checking operations. Defaults to 'Interval' duration.
-                type: string
-              validation:
-                description: Validate the Kubernetes objects before applying them on the cluster. The validation strategy can be 'client' (local dry-run), 'server' (APIServer dry-run) or 'none'.
-                enum:
-                - none
-                - client
-                - server
-                type: string
-            required:
-            - interval
-            - prune
-            - sourceRef
-            type: object
-          status:
-            description: KustomizationStatus defines the observed state of a kustomization.
-            properties:
-              conditions:
-                items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                  type: array
+                lastAppliedRevision:
+                  description: The last successfully applied revision. The revision format for Git sources is <branch|tag>/<commit-sha>.
+                  type: string
+                lastAttemptedRevision:
+                  description: LastAttemptedRevision is the revision of the last reconciliation attempt.
+                  type: string
+                lastHandledReconcileAt:
+                  description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change can be detected.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last reconciled generation.
+                  format: int64
+                  type: integer
+                snapshot:
+                  description: The last successfully applied revision metadata.
                   properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
+                    checksum:
+                      description: The manifests sha1 checksum.
                       type: string
-                    message:
-                      description: message is a human readable message indicating details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-              lastAppliedRevision:
-                description: The last successfully applied revision. The revision format for Git sources is <branch|tag>/<commit-sha>.
-                type: string
-              lastAttemptedRevision:
-                description: LastAttemptedRevision is the revision of the last reconciliation attempt.
-                type: string
-              lastHandledReconcileAt:
-                description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change can be detected.
-                type: string
-              observedGeneration:
-                description: ObservedGeneration is the last reconciled generation.
-                format: int64
-                type: integer
-              snapshot:
-                description: The last successfully applied revision metadata.
-                properties:
-                  checksum:
-                    description: The manifests sha1 checksum.
-                    type: string
-                  entries:
-                    description: A list of Kubernetes kinds grouped by namespace.
-                    items:
-                      description: Snapshot holds the metadata of namespaced Kubernetes objects
-                      properties:
-                        kinds:
-                          additionalProperties:
+                    entries:
+                      description: A list of Kubernetes kinds grouped by namespace.
+                      items:
+                        description: Snapshot holds the metadata of namespaced Kubernetes objects
+                        properties:
+                          kinds:
+                            additionalProperties:
+                              type: string
+                            description: The list of Kubernetes kinds.
+                            type: object
+                          namespace:
+                            description: The namespace of this entry.
                             type: string
-                          description: The list of Kubernetes kinds.
-                          type: object
-                        namespace:
-                          description: The namespace of this entry.
-                          type: string
-                      required:
-                      - kinds
-                      type: object
-                    type: array
-                required:
-                - checksum
-                - entries
-                type: object
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                        required:
+                          - kinds
+                        type: object
+                      type: array
+                  required:
+                    - checksum
+                    - entries
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/helm/flux-app/crds/provider.yaml
+++ b/helm/flux-app/crds/provider.yaml
@@ -16,121 +16,123 @@ spec:
     singular: provider
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: Provider is the Schema for the providers API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ProviderSpec defines the desired state of Provider
-            properties:
-              address:
-                description: HTTP/S webhook address of this provider
-                pattern: ^(http|https)://
-                type: string
-              channel:
-                description: Alert channel for this provider
-                type: string
-              proxy:
-                description: HTTP/S address of the proxy
-                pattern: ^(http|https)://
-                type: string
-              secretRef:
-                description: Secret reference containing the provider webhook URL
-                properties:
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                    type: string
-                type: object
-              type:
-                description: Type of provider
-                enum:
-                - slack
-                - discord
-                - msteams
-                - rocket
-                - generic
-                - github
-                - gitlab
-                - bitbucket
-                - azuredevops
-                type: string
-              username:
-                description: Bot username for this provider
-                type: string
-            required:
-            - type
-            type: object
-          status:
-            description: ProviderStatus defines the observed state of Provider
-            properties:
-              conditions:
-                items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: Provider is the Schema for the providers API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ProviderSpec defines the desired state of Provider
+              properties:
+                address:
+                  description: HTTP/S webhook address of this provider
+                  pattern: ^(http|https)://
+                  type: string
+                channel:
+                  description: Alert channel for this provider
+                  type: string
+                proxy:
+                  description: HTTP/S address of the proxy
+                  pattern: ^(http|https)://
+                  type: string
+                secretRef:
+                  description: Secret reference containing the provider webhook URL using "address" as data key
                   properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human readable message indicating details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    name:
+                      description: Name of the referent
                       type: string
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    - name
                   type: object
-                type: array
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                type:
+                  description: Type of provider
+                  enum:
+                    - slack
+                    - discord
+                    - msteams
+                    - rocket
+                    - generic
+                    - github
+                    - gitlab
+                    - bitbucket
+                    - azuredevops
+                  type: string
+                username:
+                  description: Bot username for this provider
+                  type: string
+              required:
+                - type
+              type: object
+            status:
+              description: ProviderStatus defines the observed state of Provider
+              properties:
+                conditions:
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/helm/flux-app/crds/receiver.yaml
+++ b/helm/flux-app/crds/receiver.yaml
@@ -16,147 +16,157 @@ spec:
     singular: receiver
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: Receiver is the Schema for the receivers API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ReceiverSpec defines the desired state of Receiver
-            properties:
-              events:
-                description: A list of events to handle, e.g. 'push' for GitHub or 'Push Hook' for GitLab.
-                items:
-                  type: string
-                type: array
-              resources:
-                description: A list of resources to be notified about changes.
-                items:
-                  description: CrossNamespaceObjectReference contains enough information to let you locate the typed referenced object at cluster level
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: Receiver is the Schema for the receivers API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ReceiverSpec defines the desired state of Receiver
+              properties:
+                events:
+                  description: A list of events to handle, e.g. 'push' for GitHub or 'Push Hook' for GitLab.
+                  items:
+                    type: string
+                  type: array
+                resources:
+                  description: A list of resources to be notified about changes.
+                  items:
+                    description: CrossNamespaceObjectReference contains enough information to let you locate the typed referenced object at cluster level
+                    properties:
+                      apiVersion:
+                        description: API version of the referent
+                        type: string
+                      kind:
+                        description: Kind of the referent
+                        enum:
+                          - Bucket
+                          - GitRepository
+                          - Kustomization
+                          - HelmRelease
+                          - HelmChart
+                          - HelmRepository
+                          - ImageRepository
+                          - ImagePolicy
+                          - ImageUpdateAutomation
+                        type: string
+                      name:
+                        description: Name of the referent
+                        maxLength: 53
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: Namespace of the referent
+                        maxLength: 53
+                        minLength: 1
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                secretRef:
+                  description: Secret reference containing the token used to validate the payload authenticity
                   properties:
-                    apiVersion:
-                      description: API version of the referent
-                      type: string
-                    kind:
-                      description: Kind of the referent
-                      enum:
-                      - Bucket
-                      - GitRepository
-                      - Kustomization
-                      - HelmRelease
-                      - HelmChart
-                      - HelmRepository
-                      type: string
                     name:
                       description: Name of the referent
-                      maxLength: 53
-                      minLength: 1
-                      type: string
-                    namespace:
-                      description: Namespace of the referent
-                      maxLength: 53
-                      minLength: 1
                       type: string
                   required:
-                  - name
+                    - name
                   type: object
-                type: array
-              secretRef:
-                description: Secret reference containing the token used to validate the payload authenticity
-                properties:
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                    type: string
-                type: object
-              suspend:
-                description: This flag tells the controller to suspend subsequent events handling. Defaults to false.
-                type: boolean
-              type:
-                description: Type of webhook sender, used to determine the validation procedure and payload deserialization.
-                enum:
-                - generic
-                - github
-                - gitlab
-                - bitbucket
-                - harbor
-                type: string
-            required:
-            - resources
-            - type
-            type: object
-          status:
-            description: ReceiverStatus defines the observed state of Receiver
-            properties:
-              conditions:
-                items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human readable message indicating details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-              url:
-                description: Generated webhook URL in the format of '/hook/sha256sum(token+name+namespace)'.
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                suspend:
+                  description: This flag tells the controller to suspend subsequent events handling. Defaults to false.
+                  type: boolean
+                type:
+                  description: Type of webhook sender, used to determine the validation procedure and payload deserialization.
+                  enum:
+                    - generic
+                    - generic-hmac
+                    - github
+                    - gitlab
+                    - bitbucket
+                    - harbor
+                    - dockerhub
+                    - quay
+                    - gcr
+                    - nexus
+                  type: string
+              required:
+                - resources
+                - type
+              type: object
+            status:
+              description: ReceiverStatus defines the observed state of Receiver
+              properties:
+                conditions:
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                url:
+                  description: Generated webhook URL in the format of '/hook/sha256sum(token+name+namespace)'.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/helm/flux-app/templates/_helpers.tpl
+++ b/helm/flux-app/templates/_helpers.tpl
@@ -43,3 +43,10 @@ app.kubernetes.io/instance: {{ .Release.Name | quote }}
 {{- define "crdInstallSelector" -}}
 {{- printf "%s" "crd-install-hook" -}}
 {{- end -}}
+
+{{/* Usage:
+    {{ include "controllerVolumeName" (merge (dict "volumeName" "hello") .) | quote }}
+*/}}
+{{- define "controllerVolumeName" -}}
+{{- printf "%s-controller-%s-volume" (include "name" .) .volumeName -}}
+{{- end -}}

--- a/helm/flux-app/templates/install.yaml
+++ b/helm/flux-app/templates/install.yaml
@@ -99,6 +99,7 @@ spec:
     rule: MustRunAs
   volumes:
     - persistentVolumeClaim
+    - secret
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -543,6 +544,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            runAs: 100
           volumeMounts:
             - mountPath: /tmp
               name: temp
@@ -625,6 +627,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            runAs: 100
           volumeMounts:
             - mountPath: /tmp
               name: temp
@@ -707,6 +710,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            runAs: 100
           volumeMounts:
             - mountPath: /tmp
               name: temp
@@ -794,6 +798,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            runAs: 100
           volumeMounts:
             - mountPath: /tmp
               name: temp
@@ -881,6 +886,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            runAs: 100
           volumeMounts:
             - mountPath: /tmp
               name: temp
@@ -968,6 +974,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            runAs: 100
           volumeMounts:
             - mountPath: /data
               name: data

--- a/helm/flux-app/templates/install.yaml
+++ b/helm/flux-app/templates/install.yaml
@@ -79,7 +79,7 @@ metadata:
     app.kubernetes.io/name: {{ include "name" . | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
     helm.sh/chart: {{ include "chart" . | quote }}
-  name: {{ include "name" . }}-pvc-psp'
+  name: {{ printf "%s-pvc-psp" (include "name" .) | quote }}
 spec:
   fsGroup:
     ranges:

--- a/helm/flux-app/templates/install.yaml
+++ b/helm/flux-app/templates/install.yaml
@@ -289,6 +289,150 @@ spec:
     helm.sh/chart: {{ include "chart" . | quote }}
   type: ClusterIP
 ---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "name" . | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "chart" . | quote }}
+  name: {{ include "controllerVolumeName" (merge (dict "volumeName" "helm-controller-temp") .) | quote }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100MiB
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "name" . | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "chart" . | quote }}
+  name: {{ include "controllerVolumeName" (merge (dict "volumeName" "image-automation-controller-temp") .) | quote }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100MiB
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "name" . | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "chart" . | quote }}
+  name: {{ include "controllerVolumeName" (merge (dict "volumeName" "image-reflector-controller-data") .) | quote }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100MiB
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "name" . | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "chart" . | quote }}
+  name: {{ include "controllerVolumeName" (merge (dict "volumeName" "image-reflector-controller-temp") .) | quote }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100MiB
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "name" . | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "chart" . | quote }}
+  name: {{ include "controllerVolumeName" (merge (dict "volumeName" "kustomize-controller-temp") .) | quote }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100MiB
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "name" . | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "chart" . | quote }}
+  name: {{ include "controllerVolumeName" (merge (dict "volumeName" "notification-controller-temp") .) | quote }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100MiB
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "name" . | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "chart" . | quote }}
+  name: {{ include "controllerVolumeName" (merge (dict "volumeName" "source-controller-data") .) | quote }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100MiB
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "name" . | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "chart" . | quote }}
+  name: {{ include "controllerVolumeName" (merge (dict "volumeName" "source-controller-temp") .) | quote }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100MiB
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -367,8 +511,9 @@ spec:
       serviceAccountName: helm-controller
       terminationGracePeriodSeconds: 600
       volumes:
-        - emptyDir: {}
-          name: temp
+        - name: temp
+          persistentVolumeClaim:
+            claimName: {{ include "controllerVolumeName" (merge (dict "volumeName" "helm-controller-temp") .) | quote }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -448,8 +593,9 @@ spec:
       serviceAccountName: image-automation-controller
       terminationGracePeriodSeconds: 10
       volumes:
-        - emptyDir: {}
-          name: temp
+        - name: temp
+          persistentVolumeClaim:
+            claimName: {{ include "controllerVolumeName" (merge (dict "volumeName" "image-automation-controller-temp") .) | quote }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -531,10 +677,12 @@ spec:
       serviceAccountName: image-reflector-controller
       terminationGracePeriodSeconds: 10
       volumes:
-        - emptyDir: {}
-          name: temp
-        - emptyDir: {}
-          name: data
+        - name: temp
+          persistentVolumeClaim:
+            claimName: {{ include "controllerVolumeName" (merge (dict "volumeName" "image-reflector-controller-temp") .) | quote }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "controllerVolumeName" (merge (dict "volumeName" "image-reflector-controller-data") .) | quote }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -616,8 +764,9 @@ spec:
       serviceAccountName: kustomize-controller
       terminationGracePeriodSeconds: 60
       volumes:
-        - emptyDir: {}
-          name: temp
+        - name: temp
+          persistentVolumeClaim:
+            claimName: {{ include "controllerVolumeName" (merge (dict "volumeName" "kustomize-controller-temp") .) | quote }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -700,8 +849,9 @@ spec:
       serviceAccountName: notification-controller
       terminationGracePeriodSeconds: 10
       volumes:
-        - emptyDir: {}
-          name: temp
+        - name: temp
+          persistentVolumeClaim:
+            claimName: {{ include "controllerVolumeName" (merge (dict "volumeName" "notification-controller-temp") .) | quote }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -788,10 +938,12 @@ spec:
       serviceAccountName: source-controller
       terminationGracePeriodSeconds: 10
       volumes:
-        - emptyDir: {}
-          name: data
-        - emptyDir: {}
-          name: tmp
+        - name: tmp
+          persistentVolumeClaim:
+            claimName: {{ include "controllerVolumeName" (merge (dict "volumeName" "source-controller-temp") .) | quote }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "controllerVolumeName" (merge (dict "volumeName" "source-controller-data") .) | quote }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/helm/flux-app/templates/install.yaml
+++ b/helm/flux-app/templates/install.yaml
@@ -305,7 +305,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100MiB
+      storage: 100Mi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -323,7 +323,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100MiB
+      storage: 100Mi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -341,7 +341,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100MiB
+      storage: 100Mi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -359,7 +359,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100MiB
+      storage: 100Mi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -377,7 +377,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100MiB
+      storage: 100Mi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -395,7 +395,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100MiB
+      storage: 100Mi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -413,7 +413,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100MiB
+      storage: 100Mi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -431,7 +431,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100MiB
+      storage: 100Mi
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/helm/flux-app/templates/install.yaml
+++ b/helm/flux-app/templates/install.yaml
@@ -1,5 +1,77 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "name" . | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "chart" . | quote }}
+  name: helm-controller
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "name" . | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "chart" . | quote }}
+  name: image-automation-controller
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "name" . | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "chart" . | quote }}
+  name: image-reflector-controller
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "name" . | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "chart" . | quote }}
+  name: kustomize-controller
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "name" . | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "chart" . | quote }}
+  name: notification-controller
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "name" . | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "chart" . | quote }}
+  name: source-controller
+  namespace: {{ .Release.Namespace }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
@@ -8,7 +80,6 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
     helm.sh/chart: {{ include "chart" . | quote }}
   name: crd-controller
-  namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
       - source.toolkit.fluxcd.io
@@ -35,12 +106,19 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - ""
+      - image.toolkit.fluxcd.io
     resources:
-      - configmaps
-      - configmaps/status
+      - '*'
     verbs:
       - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - ""
     resources:
@@ -48,26 +126,31 @@ rules:
     verbs:
       - create
       - patch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  labels:
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/name: {{ include "name" . | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-    helm.sh/chart: {{ include "chart" . | quote }}
-  name: crd-controller
-  namespace: {{ .Release.Namespace }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: crd-controller
-subjects:
-  - kind: ServiceAccount
-    name: default
-    namespace: {{ .Release.Namespace }}
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - configmaps/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -85,7 +168,44 @@ roleRef:
   name: cluster-admin
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: kustomize-controller
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: helm-controller
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "name" . | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "chart" . | quote }}
+  name: crd-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crd-controller
+subjects:
+  - kind: ServiceAccount
+    name: kustomize-controller
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: helm-controller
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: source-controller
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: notification-controller
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: image-reflector-controller
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: image-automation-controller
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: v1
@@ -207,14 +327,14 @@ spec:
             - --events-addr=http://notification-controller/
             - --watch-all-namespaces
             - --log-level=info
-            - --log-json
+            - --log-encoding=json
             - --enable-leader-election
           env:
             - name: RUNTIME_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: '{{ .Values.images.registry }}/{{ .Values.images.helm_controller.image }}:v0.4.4'
+          image: '{{ .Values.images.registry }}/{{ .Values.images.helm_controller.image }}:v0.6.1'
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -244,6 +364,7 @@ spec:
           volumeMounts:
             - mountPath: /tmp
               name: temp
+      serviceAccountName: helm-controller
       terminationGracePeriodSeconds: 600
       volumes:
         - emptyDir: {}
@@ -287,14 +408,14 @@ spec:
             - --events-addr=http://notification-controller/
             - --watch-all-namespaces
             - --log-level=info
-            - --log-json
+            - --log-encoding=json
             - --enable-leader-election
           env:
             - name: RUNTIME_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: '{{ .Values.images.registry }}/{{ .Values.images.image_automation_controller.image }}:v0.2.0'
+          image: '{{ .Values.images.registry }}/{{ .Values.images.image_automation_controller.image }}:v0.4.0'
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -324,6 +445,7 @@ spec:
           volumeMounts:
             - mountPath: /tmp
               name: temp
+      serviceAccountName: image-automation-controller
       terminationGracePeriodSeconds: 10
       volumes:
         - emptyDir: {}
@@ -367,14 +489,14 @@ spec:
             - --events-addr=http://notification-controller/
             - --watch-all-namespaces
             - --log-level=info
-            - --log-json
+            - --log-encoding=json
             - --enable-leader-election
           env:
             - name: RUNTIME_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: '{{ .Values.images.registry }}/{{ .Values.images.image_reflector_controller.image }}:v0.1.0'
+          image: '{{ .Values.images.registry }}/{{ .Values.images.image_reflector_controller.image }}:v0.5.0'
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -406,6 +528,7 @@ spec:
               name: temp
             - mountPath: /data
               name: data
+      serviceAccountName: image-reflector-controller
       terminationGracePeriodSeconds: 10
       volumes:
         - emptyDir: {}
@@ -451,14 +574,14 @@ spec:
             - --events-addr=http://notification-controller/
             - --watch-all-namespaces
             - --log-level=info
-            - --log-json
+            - --log-encoding=json
             - --enable-leader-election
           env:
             - name: RUNTIME_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: '{{ .Values.images.registry }}/{{ .Values.images.kustomize_controller.image }}:v0.5.3'
+          image: '{{ .Values.images.registry }}/{{ .Values.images.kustomize_controller.image }}:v0.7.4'
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -490,6 +613,7 @@ spec:
               name: temp
       securityContext:
         fsGroup: 1337
+      serviceAccountName: kustomize-controller
       terminationGracePeriodSeconds: 60
       volumes:
         - emptyDir: {}
@@ -532,14 +656,14 @@ spec:
         - args:
             - --watch-all-namespaces
             - --log-level=info
-            - --log-json
+            - --log-encoding=json
             - --enable-leader-election
           env:
             - name: RUNTIME_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: '{{ .Values.images.registry }}/{{ .Values.images.notification_controller.image }}:v0.5.0'
+          image: '{{ .Values.images.registry }}/{{ .Values.images.notification_controller.image }}:v0.7.1'
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -573,6 +697,7 @@ spec:
           volumeMounts:
             - mountPath: /tmp
               name: temp
+      serviceAccountName: notification-controller
       terminationGracePeriodSeconds: 10
       volumes:
         - emptyDir: {}
@@ -598,6 +723,8 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name | quote }}
       app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
       app.kubernetes.io/name: {{ include "name" . | quote }}
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:
@@ -616,7 +743,7 @@ spec:
             - --events-addr=http://notification-controller/
             - --watch-all-namespaces
             - --log-level=info
-            - --log-json
+            - --log-encoding=json
             - --enable-leader-election
             - --storage-path=/data
             - --storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
@@ -625,18 +752,20 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: '{{ .Values.images.registry }}/{{ .Values.images.source_controller.image }}:v0.5.6'
+          image: '{{ .Values.images.registry }}/{{ .Values.images.source_controller.image }}:v0.7.3'
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
-              path: /
-              port: http
+              path: /healthz
+              port: healthz
           name: manager
           ports:
             - containerPort: 9090
               name: http
             - containerPort: 8080
               name: http-prom
+            - containerPort: 9440
+              name: healthz
           readinessProbe:
             httpGet:
               path: /
@@ -656,6 +785,7 @@ spec:
               name: data
             - mountPath: /tmp
               name: tmp
+      serviceAccountName: source-controller
       terminationGracePeriodSeconds: 10
       volumes:
         - emptyDir: {}
@@ -721,9 +851,12 @@ metadata:
   name: deny-ingress
   namespace: {{ .Release.Namespace }}
 spec:
+  egress:
+    - {}
   ingress:
     - from:
         - podSelector: {}
   podSelector: {}
   policyTypes:
     - Ingress
+    - Egress

--- a/helm/flux-app/templates/install.yaml
+++ b/helm/flux-app/templates/install.yaml
@@ -343,7 +343,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100Mi
+      storage: {{ .Values.volumes.helmController.temp.size | quote }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -361,7 +361,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100Mi
+      storage: {{ .Values.volumes.imageAutomationController.temp.size | quote }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -379,7 +379,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100Mi
+      storage: {{ .Values.volumes.imageReflectorController.data.size | quote }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -397,7 +397,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100Mi
+      storage: {{ .Values.volumes.imageReflectorController.temp.size | quote }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -415,7 +415,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100Mi
+      storage: {{ .Values.volumes.kustomizeController.temp.size | quote }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -433,7 +433,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100Mi
+      storage: {{ .Values.volumes.notificationController.temp.size | quote }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -451,7 +451,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100Mi
+      storage: {{ .Values.volumes.sourceController.data.size | quote }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -469,7 +469,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100Mi
+      storage: {{ .Values.volumes.sourceController.temp.size | quote }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/helm/flux-app/templates/install.yaml
+++ b/helm/flux-app/templates/install.yaml
@@ -544,7 +544,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-            runAs: 100
+            runAsUser: 100
           volumeMounts:
             - mountPath: /tmp
               name: temp
@@ -627,7 +627,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-            runAs: 100
+            runAsUser: 100
           volumeMounts:
             - mountPath: /tmp
               name: temp
@@ -710,7 +710,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-            runAs: 100
+            runAsUser: 100
           volumeMounts:
             - mountPath: /tmp
               name: temp
@@ -798,7 +798,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-            runAs: 100
+            runAsUser: 100
           volumeMounts:
             - mountPath: /tmp
               name: temp
@@ -886,7 +886,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-            runAs: 100
+            runAsUser: 100
           volumeMounts:
             - mountPath: /tmp
               name: temp
@@ -974,7 +974,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-            runAs: 100
+            runAsUser: 100
           volumeMounts:
             - mountPath: /data
               name: data

--- a/helm/flux-app/templates/install.yaml
+++ b/helm/flux-app/templates/install.yaml
@@ -81,6 +81,7 @@ metadata:
     helm.sh/chart: {{ include "chart" . | quote }}
   name: {{ printf "%s-pvc-psp" (include "name" .) | quote }}
 spec:
+  allowPrivilegeEscalation: false
   fsGroup:
     ranges:
       - max: 65535
@@ -939,7 +940,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: '{{ .Values.images.registry }}/{{ .Values.images.source_controller.image }}:v0.7.3'
+          image: '{{ .Values.images.registry }}/{{ .Values.images.source_controller.image }}:v0.7.4'
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/helm/flux-app/templates/install.yaml
+++ b/helm/flux-app/templates/install.yaml
@@ -70,6 +70,35 @@ metadata:
   name: source-controller
   namespace: {{ .Release.Namespace }}
 ---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "name" . | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "chart" . | quote }}
+  name: {{ include "name" . }}-pvc-psp'
+spec:
+  fsGroup:
+    ranges:
+      - max: 65535
+        min: 1
+    rule: MustRunAs
+  privileged: false
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+      - max: 65535
+        min: 1
+    rule: MustRunAs
+  volumes:
+    - persistentVolumeClaim
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -151,6 +180,14 @@ rules:
       - update
       - patch
       - delete
+  - apiGroups:
+      - policy
+    resourceNames:
+      - {{ printf "%s-pvc-psp" (include "name" .) | quote }}
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/helm/flux-app/templates/install.yaml
+++ b/helm/flux-app/templates/install.yaml
@@ -516,7 +516,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: '{{ .Values.images.registry }}/{{ .Values.images.helm_controller.image }}:v0.6.1'
+          image: '{{ .Values.images.registry }}/{{ .Values.images.helmController.image }}:v0.6.1'
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -598,7 +598,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: '{{ .Values.images.registry }}/{{ .Values.images.image_automation_controller.image }}:v0.4.0'
+          image: '{{ .Values.images.registry }}/{{ .Values.images.imageAutomationController.image }}:v0.4.0'
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -680,7 +680,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: '{{ .Values.images.registry }}/{{ .Values.images.image_reflector_controller.image }}:v0.5.0'
+          image: '{{ .Values.images.registry }}/{{ .Values.images.imageReflectorController.image }}:v0.5.0'
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -767,7 +767,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: '{{ .Values.images.registry }}/{{ .Values.images.kustomize_controller.image }}:v0.7.4'
+          image: '{{ .Values.images.registry }}/{{ .Values.images.kustomizeController.image }}:v0.7.4'
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -850,7 +850,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: '{{ .Values.images.registry }}/{{ .Values.images.notification_controller.image }}:v0.7.1'
+          image: '{{ .Values.images.registry }}/{{ .Values.images.notificationController.image }}:v0.7.1'
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -940,7 +940,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: '{{ .Values.images.registry }}/{{ .Values.images.source_controller.image }}:v0.7.4'
+          image: '{{ .Values.images.registry }}/{{ .Values.images.sourceController.image }}:v0.7.4'
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/helm/flux-app/values.schema.json
+++ b/helm/flux-app/values.schema.json
@@ -7,19 +7,19 @@
       "type": "object",
       "required": [
         "registry",
-        "helm_controller",
-        "source_controller",
-        "kustomize_controller",
-        "notification_controller",
-        "image_automation_controller",
-        "image_reflector_controller"
+        "helmController",
+        "sourceController",
+        "kustomizeController",
+        "notificationController",
+        "imageAutomationController",
+        "imageReflectorController"
       ],
       "properties": {
         "registry": {
           "type": "string",
           "minLength": 1
         },
-        "helm_controller": {
+        "helmController": {
           "type": "object",
           "required": ["image"],
           "properties": {
@@ -30,7 +30,7 @@
           },
           "additionalProperties": false
         },
-        "source_controller": {
+        "sourceController": {
           "type": "object",
           "required": ["image"],
           "properties": {
@@ -41,7 +41,7 @@
           },
           "additionalProperties": false
         },
-        "kustomize_controller": {
+        "notifictionController": {
           "type": "object",
           "required": ["image"],
           "properties": {
@@ -52,7 +52,7 @@
           },
           "additionalProperties": false
         },
-        "notification_controller": {
+        "kustomizeController": {
           "type": "object",
           "required": ["image"],
           "properties": {
@@ -63,7 +63,7 @@
           },
           "additionalProperties": false
         },
-        "image_automation_controller": {
+        "imageAutomationController": {
           "type": "object",
           "required": ["image"],
           "properties": {
@@ -74,7 +74,7 @@
           },
           "additionalProperties": false
         },
-        "image_reflector_controller": {
+        "imageReflectorController": {
           "type": "object",
           "required": ["image"],
           "properties": {

--- a/helm/flux-app/values.schema.json
+++ b/helm/flux-app/values.schema.json
@@ -344,5 +344,5 @@
       "additionalProperties": false
     }
   },
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/helm/flux-app/values.schema.json
+++ b/helm/flux-app/values.schema.json
@@ -1,6 +1,30 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "type": "object",
+  "definitions": {
+    "controllerImageProps": {
+      "type": "object",
+      "required": ["image"],
+      "properties": {
+        "image": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "volumeProps": {
+      "type": "object",
+      "required": ["size"],
+      "properties": {
+        "size": {
+          "type": "string",
+          "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
   "required": ["images", "sources", "kustomizations", "volumes"],
   "properties": {
     "images": {
@@ -20,70 +44,22 @@
           "minLength": 1
         },
         "helmController": {
-          "type": "object",
-          "required": ["image"],
-          "properties": {
-            "image": {
-              "type": "string",
-              "minLength": 1
-            }
-          },
-          "additionalProperties": false
+          "$ref": "#/definitions/controllerImageProps"
         },
         "sourceController": {
-          "type": "object",
-          "required": ["image"],
-          "properties": {
-            "image": {
-              "type": "string",
-              "minLength": 1
-            }
-          },
-          "additionalProperties": false
+          "$ref": "#/definitions/controllerImageProps"
         },
         "notificationController": {
-          "type": "object",
-          "required": ["image"],
-          "properties": {
-            "image": {
-              "type": "string",
-              "minLength": 1
-            }
-          },
-          "additionalProperties": false
+          "$ref": "#/definitions/controllerImageProps"
         },
         "kustomizeController": {
-          "type": "object",
-          "required": ["image"],
-          "properties": {
-            "image": {
-              "type": "string",
-              "minLength": 1
-            }
-          },
-          "additionalProperties": false
+          "$ref": "#/definitions/controllerImageProps"
         },
         "imageAutomationController": {
-          "type": "object",
-          "required": ["image"],
-          "properties": {
-            "image": {
-              "type": "string",
-              "minLength": 1
-            }
-          },
-          "additionalProperties": false
+          "$ref": "#/definitions/controllerImageProps"
         },
         "imageReflectorController": {
-          "type": "object",
-          "required": ["image"],
-          "properties": {
-            "image": {
-              "type": "string",
-              "minLength": 1
-            }
-          },
-          "additionalProperties": false
+          "$ref": "#/definitions/controllerImageProps"
         }
       },
       "additionalProperties": false
@@ -215,15 +191,7 @@
           "required": ["temp"],
           "properties": {
             "temp": {
-              "type": "object",
-              "required": ["size"],
-              "properties": {
-                "size": {
-                  "type": "string",
-                  "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                }
-              },
-              "additionalProperties": false
+              "$ref": "#/definitions/volumeProps"
             }
           },
           "additionalProperties": false
@@ -233,26 +201,10 @@
           "required": ["temp", "data"],
           "properties": {
             "temp": {
-              "type": "object",
-              "required": ["size"],
-              "properties": {
-                "size": {
-                  "type": "string",
-                  "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                }
-              },
-              "additionalProperties": false
+              "$ref": "#/definitions/volumeProps"
             },
             "data": {
-              "type": "object",
-              "required": ["size"],
-              "properties": {
-                "size": {
-                  "type": "string",
-                  "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                }
-              },
-              "additionalProperties": false
+              "$ref": "#/definitions/volumeProps"
             }
           },
           "additionalProperties": false
@@ -262,15 +214,7 @@
           "required": ["temp"],
           "properties": {
             "temp": {
-              "type": "object",
-              "required": ["size"],
-              "properties": {
-                "size": {
-                  "type": "string",
-                  "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                }
-              },
-              "additionalProperties": false
+              "$ref": "#/definitions/volumeProps"
             }
           },
           "additionalProperties": false
@@ -280,15 +224,7 @@
           "required": ["temp"],
           "properties": {
             "temp": {
-              "type": "object",
-              "required": ["size"],
-              "properties": {
-                "size": {
-                  "type": "string",
-                  "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                }
-              },
-              "additionalProperties": false
+              "$ref": "#/definitions/volumeProps"
             }
           },
           "additionalProperties": false
@@ -298,15 +234,7 @@
           "required": ["temp"],
           "properties": {
             "temp": {
-              "type": "object",
-              "required": ["size"],
-              "properties": {
-                "size": {
-                  "type": "string",
-                  "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                }
-              },
-              "additionalProperties": false
+              "$ref": "#/definitions/volumeProps"
             }
           },
           "additionalProperties": false
@@ -316,26 +244,10 @@
           "required": ["temp", "data"],
           "properties": {
             "temp": {
-              "type": "object",
-              "required": ["size"],
-              "properties": {
-                "size": {
-                  "type": "string",
-                  "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                }
-              },
-              "additionalProperties": false
+              "$ref": "#/definitions/volumeProps"
             },
             "data": {
-              "type": "object",
-              "required": ["size"],
-              "properties": {
-                "size": {
-                  "type": "string",
-                  "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                }
-              },
-              "additionalProperties": false
+              "$ref": "#/definitions/volumeProps"
             }
           },
           "additionalProperties": false

--- a/helm/flux-app/values.schema.json
+++ b/helm/flux-app/values.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "type": "object",
-  "required": ["images", "sources", "kustomizations"],
+  "required": ["images", "sources", "kustomizations", "volumes"],
   "properties": {
     "images": {
       "type": "object",
@@ -41,7 +41,7 @@
           },
           "additionalProperties": false
         },
-        "notifictionController": {
+        "notificationController": {
           "type": "object",
           "required": ["image"],
           "properties": {
@@ -179,7 +179,7 @@
           "type": "boolean"
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "sopsEncryption": {
       "type": "object",
@@ -197,8 +197,152 @@
           }
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
+    },
+    "volumes": {
+      "type": "object",
+      "required": [
+        "helmController",
+        "sourceController",
+        "kustomizeController",
+        "notificationController",
+        "imageAutomationController",
+        "imageReflectorController"
+      ],
+      "properties": {
+        "helmController": {
+          "type": "object",
+          "required": ["temp"],
+          "properties": {
+            "temp": {
+              "type": "object",
+              "required": ["size"],
+              "properties": {
+                "size": {
+                  "type": "string",
+                  "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "sourceController": {
+          "type": "object",
+          "required": ["temp", "data"],
+          "properties": {
+            "temp": {
+              "type": "object",
+              "required": ["size"],
+              "properties": {
+                "size": {
+                  "type": "string",
+                  "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                }
+              },
+              "additionalProperties": false
+            },
+            "data": {
+              "type": "object",
+              "required": ["size"],
+              "properties": {
+                "size": {
+                  "type": "string",
+                  "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "kustomizeController": {
+          "type": "object",
+          "required": ["temp"],
+          "properties": {
+            "temp": {
+              "type": "object",
+              "required": ["size"],
+              "properties": {
+                "size": {
+                  "type": "string",
+                  "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "notificationController": {
+          "type": "object",
+          "required": ["temp"],
+          "properties": {
+            "temp": {
+              "type": "object",
+              "required": ["size"],
+              "properties": {
+                "size": {
+                  "type": "string",
+                  "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "imageAutomationController": {
+          "type": "object",
+          "required": ["temp"],
+          "properties": {
+            "temp": {
+              "type": "object",
+              "required": ["size"],
+              "properties": {
+                "size": {
+                  "type": "string",
+                  "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "imageReflectorController": {
+          "type": "object",
+          "required": ["temp", "data"],
+          "properties": {
+            "temp": {
+              "type": "object",
+              "required": ["size"],
+              "properties": {
+                "size": {
+                  "type": "string",
+                  "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                }
+              },
+              "additionalProperties": false
+            },
+            "data": {
+              "type": "object",
+              "required": ["size"],
+              "properties": {
+                "size": {
+                  "type": "string",
+                  "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
     }
   },
-  "additionalProperties": true
+  "additionalProperties": false
 }

--- a/helm/flux-app/values.yaml
+++ b/helm/flux-app/values.yaml
@@ -1,16 +1,16 @@
 images:
   registry: quay.io
-  helm_controller:
+  helmController:
     image: giantswarm/fluxcd-helm-controller
-  source_controller:
+  sourceController:
     image: giantswarm/fluxcd-source-controller
-  kustomize_controller:
+  kustomizeController:
     image: giantswarm/fluxcd-kustomize-controller
-  notification_controller:
+  notificationController:
     image: giantswarm/fluxcd-notification-controller
-  image_automation_controller:
+  imageAutomationController:
     image: giantswarm/fluxcd-image-automation-controller
-  image_reflector_controller:
+  imageReflectorController:
     image: giantswarm/fluxcd-image-reflector-controller
 
 # only GitRepository for now

--- a/helm/flux-app/values.yaml
+++ b/helm/flux-app/values.yaml
@@ -23,3 +23,28 @@ sopsEncryption:
 
 crds:
   install: true
+
+# allows to change the persistentVolumeClaim request sizes
+volumes:
+  helmController:
+    temp:
+      size: 100Mi
+  imageAutomationController:
+    temp:
+      size: 100Mi
+  imageReflectorController:
+    temp:
+      size: 100Mi
+    data:
+      size: 100Mi
+  kustomizeController:
+    temp:
+      size: 100Mi
+  notificationController:
+    temp:
+      size: 100Mi
+  sourceController:
+    temp:
+      size: 100Mi
+    data:
+      size: 100Mi


### PR DESCRIPTION
This PR updates flux-app to 0.7.7

- Replaces `emptyDir` volumes with configurable `persistentVolumeClaims`
- Rename some values to match camelCase

The changes to [`hack/kustomization.yaml`](https://github.com/giantswarm/flux-app/pull/15/files#diff-a0291ed1bce2304242a87ff0aeb699922daffcc7f79192af0a1947abbde4dfcb) tell a good story on what the general changes are.