### PR TITLE
Change default registry to docker.io

### DIFF
--- a/helm/flux-app/values.yaml
+++ b/helm/flux-app/values.yaml
@@ -1,5 +1,5 @@
 images:
-  registry: quay.io
+  registry: docker.io
   helmController:
     image: giantswarm/fluxcd-helm-controller
   sourceController:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/18835

Checked and `docker pull giantswarm/fluxcd-helm-controller:v0.3.0` works