### PR TITLE
Set max allowed memory limit for helm-controller VPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Set VPA max allowed memory limit for helm-controller.
+
 ## [0.6.0] - 2021-10-27
 
 ### Added

--- a/helm/flux-app/templates/vpa.yaml
+++ b/helm/flux-app/templates/vpa.yaml
@@ -11,11 +11,7 @@ spec:
     containerPolicies:
     - containerName: manager
       controlledValues: RequestsAndLimits
-      minAllowed:
-        cpu: {{ .Values.resources.helmController.requests.cpu }}
-        memory: {{ .Values.resources.helmController.requests.memory }}
       maxAllowed:
-        cpu: {{ .Values.resources.helmController.limits.cpu }}
         memory: {{ .Values.resources.helmController.limits.memory }}
       mode: Auto
   targetRef:

--- a/helm/flux-app/templates/vpa.yaml
+++ b/helm/flux-app/templates/vpa.yaml
@@ -11,6 +11,12 @@ spec:
     containerPolicies:
     - containerName: manager
       controlledValues: RequestsAndLimits
+      minAllowed:
+        cpu: {{ .Values.resources.helmController.requests.cpu }}
+        memory: {{ .Values.resources.helmController.requests.memory }}
+      maxAllowed:
+        cpu: {{ .Values.resources.helmController.limits.cpu }}
+        memory: {{ .Values.resources.helmController.limits.memory }}
       mode: Auto
   targetRef:
     apiVersion: apps/v1

--- a/helm/flux-app/values.yaml
+++ b/helm/flux-app/values.yaml
@@ -35,6 +35,7 @@ resources:
   helmController:
     limits:
       cpu: 1000m
+      # Set max allowed memory limit for VPA due to high memory usage.
       memory: 1Gi
     requests:
       cpu: 100m


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/19477

Without setting a max memory limit the VPA requests more resources until the pod can no longer be scheduled.

This looks related to https://github.com/fluxcd/helm-controller/issues/345 since we need to use Reconcile Strategy Revision.
