### PR TITLE
Fix PSP reference in a ClusterRole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix PSP reference in ClusterRole.
+
 ## [0.7.0] - 2021-11-08
 
 ### Added

--- a/hack/patches/crd-controller-cluster-role-patch.yaml
+++ b/hack/patches/crd-controller-cluster-role-patch.yaml
@@ -4,4 +4,4 @@
     apiGroups: ['policy']
     resources: ['podsecuritypolicies']
     verbs: ['use']
-    resourceNames: ['{{ printf "%s-pvc-psp" (include "name" .) | quote }}']
+    resourceNames: ['{{ printf "%s-pvc-psp" (include "name" .) }}']

--- a/helm/flux-app/templates/install.yaml
+++ b/helm/flux-app/templates/install.yaml
@@ -201,7 +201,7 @@ rules:
   - apiGroups:
       - policy
     resourceNames:
-      - '{{ printf "%s-pvc-psp" (include "name" .) | quote }}'
+      - '{{ printf "%s-pvc-psp" (include "name" .) }}'
     resources:
       - podsecuritypolicies
     verbs:


### PR DESCRIPTION
Related Slack thread: https://gigantic.slack.com/archives/C01MP0EL6QK/p1637147691454300

Changes `-"'flux-app-pvc-psp'"` to `- 'flux-app-pvc-psp'`