### PR TITLE
Make source-controller artifact cache persistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- added functional and upgrade tests
+### Added
+
+- Add functional and upgrade tests
+
+### Changed
+
+- Attach PVC to source-controller for artifact persistence
 
 ## [0.7.1] - 2021-11-17
 

--- a/hack/additional-resources/pvc-psp.yaml
+++ b/hack/additional-resources/pvc-psp.yaml
@@ -22,3 +22,4 @@ spec:
   volumes:
   - 'emptyDir'
   - 'secret'
+  - 'persistentVolumeClaim'

--- a/hack/additional-resources/source-controller-pv.yaml
+++ b/hack/additional-resources/source-controller-pv.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: '{{ include "controllerVolumeName" (merge (dict "volumeName" "source-controller-temp") .) | quote }}'
+  name: '{{ include "controllerVolumeName" (merge (dict "volumeName" "source-controller-temp") .) }}'
 spec:
   accessModes:
   - ReadWriteOnce
@@ -13,7 +13,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: '{{ include "controllerVolumeName" (merge (dict "volumeName" "source-controller-data") .) | quote }}'
+  name: '{{ include "controllerVolumeName" (merge (dict "volumeName" "source-controller-data") .) }}'
 spec:
   accessModes:
   - ReadWriteOnce

--- a/hack/additional-resources/source-controller-pv.yaml
+++ b/hack/additional-resources/source-controller-pv.yaml
@@ -8,6 +8,7 @@ spec:
   resources:
     requests:
       storage: '{{ .Values.volumes.sourceController.temp.size }}'
+  storageClassName: ""
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -19,3 +20,4 @@ spec:
   resources:
     requests:
       storage: '{{ .Values.volumes.sourceController.data.size }}'
+  storageClassName: ""

--- a/hack/additional-resources/source-controller-pv.yaml
+++ b/hack/additional-resources/source-controller-pv.yaml
@@ -7,7 +7,7 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: '{{ .Values.volumes.sourceController.temp.size | quote }}'
+      storage: '{{ .Values.volumes.sourceController.temp.size }}'
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -18,4 +18,4 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: '{{ .Values.volumes.sourceController.data.size | quote }}'
+      storage: '{{ .Values.volumes.sourceController.data.size }}'

--- a/hack/kustomization.yaml
+++ b/hack/kustomization.yaml
@@ -25,8 +25,9 @@ images:
 
 resources:
 - https://github.com/fluxcd/flux2/releases/download/v0.21.0/install.yaml
-- ./additional-resources/pvc-psp.yaml
 - ./additional-resources/metrics-service.yaml
+- ./additional-resources/pvc-psp.yaml
+- ./additional-resources/source-controller-pv.yaml
 
 patches:
 - path: ./patches/allow-scraping-networkpolicy-patch.yaml

--- a/hack/patches/source-controller-deploy-patch.yaml
+++ b/hack/patches/source-controller-deploy-patch.yaml
@@ -7,6 +7,15 @@
     requests:
       cpu: "{{ .Values.resources.sourceController.requests.cpu }}"
       memory: "{{ .Values.resources.sourceController.requests.memory }}"
+- op: replace
+  path: /spec/template/spec/volumes
+  value:
+    - name: data
+      persistentVolumeClaim:
+        claimName: '{{ include "controllerVolumeName" (merge (dict "volumeName" "source-controller-data") .) | quote }}'
+    - name: tmp
+      persistentVolumeClaim:
+        claimName: '{{ include "controllerVolumeName" (merge (dict "volumeName" "source-controller-temp") .) | quote }}'
 - op: add
   path: /metadata/labels/app
   value: source-controller

--- a/helm/flux-app/templates/install.yaml
+++ b/helm/flux-app/templates/install.yaml
@@ -113,6 +113,7 @@ spec:
   volumes:
     - emptyDir
     - secret
+    - persistentVolumeClaim
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -374,6 +375,44 @@ spec:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/name: '{{ include "name" . }}'
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    giantswarm.io/service_type: managed
+    helm.sh/chart: '{{ include "chart" . }}'
+  name: '{{ include "controllerVolumeName" (merge (dict "volumeName" "source-controller-data") .) | quote }}'
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: '{{ .Values.volumes.sourceController.data.size | quote }}'
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    giantswarm.io/service_type: managed
+    helm.sh/chart: '{{ include "chart" . }}'
+  name: '{{ include "controllerVolumeName" (merge (dict "volumeName" "source-controller-temp") .) | quote }}'
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: '{{ .Values.volumes.sourceController.temp.size | quote }}'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -910,10 +949,12 @@ spec:
       serviceAccountName: source-controller
       terminationGracePeriodSeconds: 10
       volumes:
-        - emptyDir: {}
-          name: data
-        - emptyDir: {}
-          name: tmp
+        - name: data
+          persistentVolumeClaim:
+            claimName: '{{ include "controllerVolumeName" (merge (dict "volumeName" "source-controller-data") .) | quote }}'
+        - name: tmp
+          persistentVolumeClaim:
+            claimName: '{{ include "controllerVolumeName" (merge (dict "volumeName" "source-controller-temp") .) | quote }}'
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/helm/flux-app/templates/install.yaml
+++ b/helm/flux-app/templates/install.yaml
@@ -394,6 +394,7 @@ spec:
   resources:
     requests:
       storage: '{{ .Values.volumes.sourceController.data.size }}'
+  storageClassName: ""
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -413,6 +414,7 @@ spec:
   resources:
     requests:
       storage: '{{ .Values.volumes.sourceController.temp.size }}'
+  storageClassName: ""
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/helm/flux-app/templates/install.yaml
+++ b/helm/flux-app/templates/install.yaml
@@ -386,7 +386,7 @@ metadata:
     app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
     giantswarm.io/service_type: managed
     helm.sh/chart: '{{ include "chart" . }}'
-  name: '{{ include "controllerVolumeName" (merge (dict "volumeName" "source-controller-data") .) | quote }}'
+  name: '{{ include "controllerVolumeName" (merge (dict "volumeName" "source-controller-data") .) }}'
   namespace: '{{ .Release.Namespace }}'
 spec:
   accessModes:
@@ -406,7 +406,7 @@ metadata:
     app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
     giantswarm.io/service_type: managed
     helm.sh/chart: '{{ include "chart" . }}'
-  name: '{{ include "controllerVolumeName" (merge (dict "volumeName" "source-controller-temp") .) | quote }}'
+  name: '{{ include "controllerVolumeName" (merge (dict "volumeName" "source-controller-temp") .) }}'
   namespace: '{{ .Release.Namespace }}'
 spec:
   accessModes:

--- a/helm/flux-app/templates/install.yaml
+++ b/helm/flux-app/templates/install.yaml
@@ -393,7 +393,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: '{{ .Values.volumes.sourceController.data.size | quote }}'
+      storage: '{{ .Values.volumes.sourceController.data.size }}'
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -412,7 +412,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: '{{ .Values.volumes.sourceController.temp.size | quote }}'
+      storage: '{{ .Values.volumes.sourceController.temp.size }}'
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/helm/flux-app/values.yaml
+++ b/helm/flux-app/values.yaml
@@ -86,23 +86,23 @@ verticalPodAutoscaler:
 volumes:
   helmController:
     temp:
-      size: 100Mi
+      size: '100Mi'
   imageAutomationController:
     temp:
-      size: 100Mi
+      size: '100Mi'
   imageReflectorController:
     temp:
-      size: 100Mi
+      size: '100Mi'
     data:
-      size: 100Mi
+      size: '100Mi'
   kustomizeController:
     temp:
-      size: 100Mi
+      size: '100Mi'
   notificationController:
     temp:
-      size: 100Mi
+      size: '100Mi'
   sourceController:
     temp:
-      size: 100Mi
+      size: '100Mi'
     data:
-      size: 500Mi
+      size: '500Mi'

--- a/helm/flux-app/values.yaml
+++ b/helm/flux-app/values.yaml
@@ -105,4 +105,4 @@ volumes:
     temp:
       size: 100Mi
     data:
-      size: 100Mi
+      size: 500Mi


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/19745

`source-controller` loses its cached artifacts if a node it was running on has been terminated. If it is unable to update artifacts after the restart, `artifact open error` keeps popping up. Subsequently, all `HelmReleases`/`Kustomizations` for affected source CR fail.

Upstream issue: https://github.com/fluxcd/flux2/issues/1969

## Changes
- mount PVCs for source-controller's storage
- enable persistentVolumeClaim in the PSP
- generate helm/flux-app/templates/install.yaml
- increase default storage size for source-controller
