### PR TITLE
Support for postBuilds and variable substitutions

### DIFF
--- a/helm/flux-app/templates/source.yaml
+++ b/helm/flux-app/templates/source.yaml
@@ -57,6 +57,10 @@ metadata:
 spec:
   interval: "{{ .interval }}"
   path: "{{ .path }}"
+{{- if .postBuild }}
+  postBuild:
+{{- .postBuild | toYaml | nindent 4 }}
+{{- end }}
   prune: {{ .prune }}
   sourceRef:
     kind: GitRepository

--- a/helm/flux-app/values.schema.json
+++ b/helm/flux-app/values.schema.json
@@ -141,6 +141,37 @@
             "type": "string",
             "minLength": 1
           },
+          "postBuild": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "substitute": {
+                "type": "object"
+              },
+              "substituteFrom": {
+                "type": ["array"],
+                "additionalItems": false,
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "kind",
+                    "name"
+                  ],
+                  "properties": {
+                    "kind": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                }
+              }
+            }
+          },
           "prune": {
             "type": "boolean"
           },


### PR DESCRIPTION
This PR introduces support for Kustomization CR's `.spec.postBuild` and thus [variable substitution feature](https://fluxcd.io/docs/components/kustomize/kustomization/#variable-substitution).

If eaither one of the:

* `.spec.postBuild:`
* `.spec.postBuild.substitute`
* `.spec.postBuild.substituteFrom` 

is given in a `null` form, then the validation yelds an error that `null` is not an object. I could accept `null` as a valid type, and then count on Kubernetes to set empty object `{}` as a value, but having an explicit error seems more informative to the user.