### PR TITLE
Move back to creating CRDs with a job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Revert to job based CRD installation as of `v0.12.0`
+
 ## [0.13.0] - 2022-08-01
 
 ### Changed

--- a/helm/flux-app/crd-base/alert.yaml
+++ b/helm/flux-app/crd-base/alert.yaml
@@ -5,8 +5,13 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+    app.kubernetes.io/name: '{{ include "name" . }}'
     app.kubernetes.io/part-of: flux
+    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
     giantswarm.io/service_type: managed
+    helm.sh/chart: '{{ include "chart" . }}'
   name: alerts.notification.toolkit.fluxcd.io
 spec:
   group: notification.toolkit.fluxcd.io

--- a/helm/flux-app/crd-base/bucket.yaml
+++ b/helm/flux-app/crd-base/bucket.yaml
@@ -5,32 +5,26 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+    app.kubernetes.io/name: '{{ include "name" . }}'
     app.kubernetes.io/part-of: flux
+    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
     giantswarm.io/service_type: managed
-  name: helmcharts.source.toolkit.fluxcd.io
+    helm.sh/chart: '{{ include "chart" . }}'
+  name: buckets.source.toolkit.fluxcd.io
 spec:
   group: source.toolkit.fluxcd.io
   names:
-    kind: HelmChart
-    listKind: HelmChartList
-    plural: helmcharts
-    shortNames:
-      - hc
-    singular: helmchart
+    kind: Bucket
+    listKind: BucketList
+    plural: buckets
+    singular: bucket
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
-        - jsonPath: .spec.chart
-          name: Chart
-          type: string
-        - jsonPath: .spec.version
-          name: Version
-          type: string
-        - jsonPath: .spec.sourceRef.kind
-          name: Source Kind
-          type: string
-        - jsonPath: .spec.sourceRef.name
-          name: Source Name
+        - jsonPath: .spec.endpoint
+          name: Endpoint
           type: string
         - jsonPath: .status.conditions[?(@.type=="Ready")].status
           name: Ready
@@ -44,7 +38,7 @@ spec:
       name: v1beta1
       schema:
         openAPIV3Schema:
-          description: HelmChart is the Schema for the helmcharts API
+          description: Bucket is the Schema for the buckets API
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -55,7 +49,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: HelmChartSpec defines the desired state of a Helm chart.
+              description: BucketSpec defines the desired state of an S3 compatible bucket
               properties:
                 accessFrom:
                   description: AccessFrom defines an Access Control List for allowing cross-namespace references to this object.
@@ -75,66 +69,60 @@ spec:
                   required:
                     - namespaceSelectors
                   type: object
-                chart:
-                  description: The name or path the Helm chart is available at in the SourceRef.
+                bucketName:
+                  description: The bucket name.
                   type: string
+                endpoint:
+                  description: The bucket endpoint address.
+                  type: string
+                ignore:
+                  description: Ignore overrides the set of excluded patterns in the .sourceignore format (which is the same as .gitignore). If not provided, a default will be used, consult the documentation for your version to find out what those are.
+                  type: string
+                insecure:
+                  description: Insecure allows connecting to a non-TLS S3 HTTP endpoint.
+                  type: boolean
                 interval:
-                  description: The interval at which to check the Source for updates.
+                  description: The interval at which to check for bucket updates.
                   type: string
-                reconcileStrategy:
-                  default: ChartVersion
-                  description: Determines what enables the creation of a new artifact. Valid values are ('ChartVersion', 'Revision'). See the documentation of the values for an explanation on their behavior. Defaults to ChartVersion when omitted.
+                provider:
+                  default: generic
+                  description: The S3 compatible storage provider name, default ('generic').
                   enum:
-                    - ChartVersion
-                    - Revision
+                    - generic
+                    - aws
+                    - gcp
                   type: string
-                sourceRef:
-                  description: The reference to the Source the chart is available at.
+                region:
+                  description: The bucket region.
+                  type: string
+                secretRef:
+                  description: The name of the secret containing authentication credentials for the Bucket.
                   properties:
-                    apiVersion:
-                      description: APIVersion of the referent.
-                      type: string
-                    kind:
-                      description: Kind of the referent, valid values are ('HelmRepository', 'GitRepository', 'Bucket').
-                      enum:
-                        - HelmRepository
-                        - GitRepository
-                        - Bucket
-                      type: string
                     name:
                       description: Name of the referent.
                       type: string
                   required:
-                    - kind
                     - name
                   type: object
                 suspend:
                   description: This flag tells the controller to suspend the reconciliation of this source.
                   type: boolean
-                valuesFile:
-                  description: Alternative values file to use as the default chart values, expected to be a relative path in the SourceRef. Deprecated in favor of ValuesFiles, for backwards compatibility the file defined here is merged before the ValuesFiles items. Ignored when omitted.
-                  type: string
-                valuesFiles:
-                  description: Alternative list of values files to use as the chart values (values.yaml is not included by default), expected to be a relative path in the SourceRef. Values files are merged in the order of this list with the last file overriding the first. Ignored when omitted.
-                  items:
-                    type: string
-                  type: array
-                version:
-                  default: '*'
-                  description: The chart version semver expression, ignored for charts from GitRepository and Bucket sources. Defaults to latest when omitted.
+                timeout:
+                  default: 60s
+                  description: The timeout for download operations, defaults to 60s.
                   type: string
               required:
-                - chart
+                - bucketName
+                - endpoint
                 - interval
-                - sourceRef
               type: object
             status:
               default:
                 observedGeneration: -1
-              description: HelmChartStatus defines the observed state of the HelmChart.
+              description: BucketStatus defines the observed state of a bucket
               properties:
                 artifact:
-                  description: Artifact represents the output of the last successful chart sync.
+                  description: Artifact represents the output of the last successful Bucket sync.
                   properties:
                     checksum:
                       description: Checksum is the SHA256 checksum of the artifact.
@@ -157,7 +145,7 @@ spec:
                     - url
                   type: object
                 conditions:
-                  description: Conditions holds the conditions for the HelmChart.
+                  description: Conditions holds the conditions for the Bucket.
                   items:
                     description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
                     properties:
@@ -208,7 +196,7 @@ spec:
                   format: int64
                   type: integer
                 url:
-                  description: URL is the download link for the last chart pulled.
+                  description: URL is the download link for the artifact output of the last Bucket sync.
                   type: string
               type: object
           type: object
@@ -217,17 +205,8 @@ spec:
       subresources:
         status: {}
     - additionalPrinterColumns:
-        - jsonPath: .spec.chart
-          name: Chart
-          type: string
-        - jsonPath: .spec.version
-          name: Version
-          type: string
-        - jsonPath: .spec.sourceRef.kind
-          name: Source Kind
-          type: string
-        - jsonPath: .spec.sourceRef.name
-          name: Source Name
+        - jsonPath: .spec.endpoint
+          name: Endpoint
           type: string
         - jsonPath: .metadata.creationTimestamp
           name: Age
@@ -241,7 +220,7 @@ spec:
       name: v1beta2
       schema:
         openAPIV3Schema:
-          description: HelmChart is the Schema for the helmcharts API.
+          description: Bucket is the Schema for the buckets API.
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -252,7 +231,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: HelmChartSpec specifies the desired state of a Helm chart.
+              description: BucketSpec specifies the required configuration to produce an Artifact for an object storage bucket.
               properties:
                 accessFrom:
                   description: 'AccessFrom specifies an Access Control List for allowing cross-namespace references to this object. NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092'
@@ -272,66 +251,61 @@ spec:
                   required:
                     - namespaceSelectors
                   type: object
-                chart:
-                  description: Chart is the name or path the Helm chart is available at in the SourceRef.
+                bucketName:
+                  description: BucketName is the name of the object storage bucket.
                   type: string
+                endpoint:
+                  description: Endpoint is the object storage address the BucketName is located at.
+                  type: string
+                ignore:
+                  description: Ignore overrides the set of excluded patterns in the .sourceignore format (which is the same as .gitignore). If not provided, a default will be used, consult the documentation for your version to find out what those are.
+                  type: string
+                insecure:
+                  description: Insecure allows connecting to a non-TLS HTTP Endpoint.
+                  type: boolean
                 interval:
-                  description: Interval is the interval at which to check the Source for updates.
+                  description: Interval at which to check the Endpoint for updates.
                   type: string
-                reconcileStrategy:
-                  default: ChartVersion
-                  description: ReconcileStrategy determines what enables the creation of a new artifact. Valid values are ('ChartVersion', 'Revision'). See the documentation of the values for an explanation on their behavior. Defaults to ChartVersion when omitted.
+                provider:
+                  default: generic
+                  description: Provider of the object storage bucket. Defaults to 'generic', which expects an S3 (API) compatible object storage.
                   enum:
-                    - ChartVersion
-                    - Revision
+                    - generic
+                    - aws
+                    - gcp
+                    - azure
                   type: string
-                sourceRef:
-                  description: SourceRef is the reference to the Source the chart is available at.
+                region:
+                  description: Region of the Endpoint where the BucketName is located in.
+                  type: string
+                secretRef:
+                  description: SecretRef specifies the Secret containing authentication credentials for the Bucket.
                   properties:
-                    apiVersion:
-                      description: APIVersion of the referent.
-                      type: string
-                    kind:
-                      description: Kind of the referent, valid values are ('HelmRepository', 'GitRepository', 'Bucket').
-                      enum:
-                        - HelmRepository
-                        - GitRepository
-                        - Bucket
-                      type: string
                     name:
                       description: Name of the referent.
                       type: string
                   required:
-                    - kind
                     - name
                   type: object
                 suspend:
-                  description: Suspend tells the controller to suspend the reconciliation of this source.
+                  description: Suspend tells the controller to suspend the reconciliation of this Bucket.
                   type: boolean
-                valuesFile:
-                  description: ValuesFile is an alternative values file to use as the default chart values, expected to be a relative path in the SourceRef. Deprecated in favor of ValuesFiles, for backwards compatibility the file specified here is merged before the ValuesFiles items. Ignored when omitted.
-                  type: string
-                valuesFiles:
-                  description: ValuesFiles is an alternative list of values files to use as the chart values (values.yaml is not included by default), expected to be a relative path in the SourceRef. Values files are merged in the order of this list with the last file overriding the first. Ignored when omitted.
-                  items:
-                    type: string
-                  type: array
-                version:
-                  default: '*'
-                  description: Version is the chart version semver expression, ignored for charts from GitRepository and Bucket sources. Defaults to latest when omitted.
+                timeout:
+                  default: 60s
+                  description: Timeout for fetch operations, defaults to 60s.
                   type: string
               required:
-                - chart
+                - bucketName
+                - endpoint
                 - interval
-                - sourceRef
               type: object
             status:
               default:
                 observedGeneration: -1
-              description: HelmChartStatus records the observed state of the HelmChart.
+              description: BucketStatus records the observed state of a Bucket.
               properties:
                 artifact:
-                  description: Artifact represents the output of the last successful reconciliation.
+                  description: Artifact represents the last successful Bucket reconciliation.
                   properties:
                     checksum:
                       description: Checksum is the SHA256 checksum of the Artifact file.
@@ -358,7 +332,7 @@ spec:
                     - url
                   type: object
                 conditions:
-                  description: Conditions holds the conditions for the HelmChart.
+                  description: Conditions holds the conditions for the Bucket.
                   items:
                     description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
                     properties:
@@ -404,16 +378,10 @@ spec:
                 lastHandledReconcileAt:
                   description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change of the annotation value can be detected.
                   type: string
-                observedChartName:
-                  description: ObservedChartName is the last observed chart name as specified by the resolved chart reference.
-                  type: string
                 observedGeneration:
-                  description: ObservedGeneration is the last observed generation of the HelmChart object.
+                  description: ObservedGeneration is the last observed generation of the Bucket object.
                   format: int64
                   type: integer
-                observedSourceArtifactRevision:
-                  description: ObservedSourceArtifactRevision is the last observed Artifact.Revision of the HelmChartSpec.SourceRef.
-                  type: string
                 url:
                   description: URL is the dynamic fetch link for the latest Artifact. It is provided on a "best effort" basis, and using the precise BucketStatus.Artifact data is recommended.
                   type: string

--- a/helm/flux-app/crd-base/gitrepository.yaml
+++ b/helm/flux-app/crd-base/gitrepository.yaml
@@ -5,8 +5,13 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+    app.kubernetes.io/name: '{{ include "name" . }}'
     app.kubernetes.io/part-of: flux
+    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
     giantswarm.io/service_type: managed
+    helm.sh/chart: '{{ include "chart" . }}'
   name: gitrepositories.source.toolkit.fluxcd.io
 spec:
   group: source.toolkit.fluxcd.io

--- a/helm/flux-app/crd-base/helmchart.yaml
+++ b/helm/flux-app/crd-base/helmchart.yaml
@@ -5,23 +5,37 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+    app.kubernetes.io/name: '{{ include "name" . }}'
     app.kubernetes.io/part-of: flux
+    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
     giantswarm.io/service_type: managed
-  name: helmrepositories.source.toolkit.fluxcd.io
+    helm.sh/chart: '{{ include "chart" . }}'
+  name: helmcharts.source.toolkit.fluxcd.io
 spec:
   group: source.toolkit.fluxcd.io
   names:
-    kind: HelmRepository
-    listKind: HelmRepositoryList
-    plural: helmrepositories
+    kind: HelmChart
+    listKind: HelmChartList
+    plural: helmcharts
     shortNames:
-      - helmrepo
-    singular: helmrepository
+      - hc
+    singular: helmchart
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
-        - jsonPath: .spec.url
-          name: URL
+        - jsonPath: .spec.chart
+          name: Chart
+          type: string
+        - jsonPath: .spec.version
+          name: Version
+          type: string
+        - jsonPath: .spec.sourceRef.kind
+          name: Source Kind
+          type: string
+        - jsonPath: .spec.sourceRef.name
+          name: Source Name
           type: string
         - jsonPath: .status.conditions[?(@.type=="Ready")].status
           name: Ready
@@ -35,7 +49,7 @@ spec:
       name: v1beta1
       schema:
         openAPIV3Schema:
-          description: HelmRepository is the Schema for the helmrepositories API
+          description: HelmChart is the Schema for the helmcharts API
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -46,7 +60,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: HelmRepositorySpec defines the reference to a Helm repository.
+              description: HelmChartSpec defines the desired state of a Helm chart.
               properties:
                 accessFrom:
                   description: AccessFrom defines an Access Control List for allowing cross-namespace references to this object.
@@ -66,42 +80,66 @@ spec:
                   required:
                     - namespaceSelectors
                   type: object
-                interval:
-                  description: The interval at which to check the upstream for updates.
+                chart:
+                  description: The name or path the Helm chart is available at in the SourceRef.
                   type: string
-                passCredentials:
-                  description: PassCredentials allows the credentials from the SecretRef to be passed on to a host that does not match the host as defined in URL. This may be required if the host of the advertised chart URLs in the index differ from the defined URL. Enabling this should be done with caution, as it can potentially result in credentials getting stolen in a MITM-attack.
-                  type: boolean
-                secretRef:
-                  description: The name of the secret containing authentication credentials for the Helm repository. For HTTP/S basic auth the secret must contain username and password fields. For TLS the secret must contain a certFile and keyFile, and/or caCert fields.
+                interval:
+                  description: The interval at which to check the Source for updates.
+                  type: string
+                reconcileStrategy:
+                  default: ChartVersion
+                  description: Determines what enables the creation of a new artifact. Valid values are ('ChartVersion', 'Revision'). See the documentation of the values for an explanation on their behavior. Defaults to ChartVersion when omitted.
+                  enum:
+                    - ChartVersion
+                    - Revision
+                  type: string
+                sourceRef:
+                  description: The reference to the Source the chart is available at.
                   properties:
+                    apiVersion:
+                      description: APIVersion of the referent.
+                      type: string
+                    kind:
+                      description: Kind of the referent, valid values are ('HelmRepository', 'GitRepository', 'Bucket').
+                      enum:
+                        - HelmRepository
+                        - GitRepository
+                        - Bucket
+                      type: string
                     name:
                       description: Name of the referent.
                       type: string
                   required:
+                    - kind
                     - name
                   type: object
                 suspend:
                   description: This flag tells the controller to suspend the reconciliation of this source.
                   type: boolean
-                timeout:
-                  default: 60s
-                  description: The timeout of index downloading, defaults to 60s.
+                valuesFile:
+                  description: Alternative values file to use as the default chart values, expected to be a relative path in the SourceRef. Deprecated in favor of ValuesFiles, for backwards compatibility the file defined here is merged before the ValuesFiles items. Ignored when omitted.
                   type: string
-                url:
-                  description: The Helm repository URL, a valid URL contains at least a protocol and host.
+                valuesFiles:
+                  description: Alternative list of values files to use as the chart values (values.yaml is not included by default), expected to be a relative path in the SourceRef. Values files are merged in the order of this list with the last file overriding the first. Ignored when omitted.
+                  items:
+                    type: string
+                  type: array
+                version:
+                  default: '*'
+                  description: The chart version semver expression, ignored for charts from GitRepository and Bucket sources. Defaults to latest when omitted.
                   type: string
               required:
+                - chart
                 - interval
-                - url
+                - sourceRef
               type: object
             status:
               default:
                 observedGeneration: -1
-              description: HelmRepositoryStatus defines the observed state of the HelmRepository.
+              description: HelmChartStatus defines the observed state of the HelmChart.
               properties:
                 artifact:
-                  description: Artifact represents the output of the last successful repository sync.
+                  description: Artifact represents the output of the last successful chart sync.
                   properties:
                     checksum:
                       description: Checksum is the SHA256 checksum of the artifact.
@@ -124,7 +162,7 @@ spec:
                     - url
                   type: object
                 conditions:
-                  description: Conditions holds the conditions for the HelmRepository.
+                  description: Conditions holds the conditions for the HelmChart.
                   items:
                     description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
                     properties:
@@ -175,7 +213,7 @@ spec:
                   format: int64
                   type: integer
                 url:
-                  description: URL is the download link for the last index fetched.
+                  description: URL is the download link for the last chart pulled.
                   type: string
               type: object
           type: object
@@ -184,8 +222,17 @@ spec:
       subresources:
         status: {}
     - additionalPrinterColumns:
-        - jsonPath: .spec.url
-          name: URL
+        - jsonPath: .spec.chart
+          name: Chart
+          type: string
+        - jsonPath: .spec.version
+          name: Version
+          type: string
+        - jsonPath: .spec.sourceRef.kind
+          name: Source Kind
+          type: string
+        - jsonPath: .spec.sourceRef.name
+          name: Source Name
           type: string
         - jsonPath: .metadata.creationTimestamp
           name: Age
@@ -199,7 +246,7 @@ spec:
       name: v1beta2
       schema:
         openAPIV3Schema:
-          description: HelmRepository is the Schema for the helmrepositories API.
+          description: HelmChart is the Schema for the helmcharts API.
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -210,7 +257,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: HelmRepositorySpec specifies the required configuration to produce an Artifact for a Helm repository index YAML.
+              description: HelmChartSpec specifies the desired state of a Helm chart.
               properties:
                 accessFrom:
                   description: 'AccessFrom specifies an Access Control List for allowing cross-namespace references to this object. NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092'
@@ -230,48 +277,66 @@ spec:
                   required:
                     - namespaceSelectors
                   type: object
-                interval:
-                  description: Interval at which to check the URL for updates.
+                chart:
+                  description: Chart is the name or path the Helm chart is available at in the SourceRef.
                   type: string
-                passCredentials:
-                  description: PassCredentials allows the credentials from the SecretRef to be passed on to a host that does not match the host as defined in URL. This may be required if the host of the advertised chart URLs in the index differ from the defined URL. Enabling this should be done with caution, as it can potentially result in credentials getting stolen in a MITM-attack.
-                  type: boolean
-                secretRef:
-                  description: SecretRef specifies the Secret containing authentication credentials for the HelmRepository. For HTTP/S basic auth the secret must contain 'username' and 'password' fields. For TLS the secret must contain a 'certFile' and 'keyFile', and/or 'caCert' fields.
+                interval:
+                  description: Interval is the interval at which to check the Source for updates.
+                  type: string
+                reconcileStrategy:
+                  default: ChartVersion
+                  description: ReconcileStrategy determines what enables the creation of a new artifact. Valid values are ('ChartVersion', 'Revision'). See the documentation of the values for an explanation on their behavior. Defaults to ChartVersion when omitted.
+                  enum:
+                    - ChartVersion
+                    - Revision
+                  type: string
+                sourceRef:
+                  description: SourceRef is the reference to the Source the chart is available at.
                   properties:
+                    apiVersion:
+                      description: APIVersion of the referent.
+                      type: string
+                    kind:
+                      description: Kind of the referent, valid values are ('HelmRepository', 'GitRepository', 'Bucket').
+                      enum:
+                        - HelmRepository
+                        - GitRepository
+                        - Bucket
+                      type: string
                     name:
                       description: Name of the referent.
                       type: string
                   required:
+                    - kind
                     - name
                   type: object
                 suspend:
-                  description: Suspend tells the controller to suspend the reconciliation of this HelmRepository.
+                  description: Suspend tells the controller to suspend the reconciliation of this source.
                   type: boolean
-                timeout:
-                  default: 60s
-                  description: Timeout of the index fetch operation, defaults to 60s.
+                valuesFile:
+                  description: ValuesFile is an alternative values file to use as the default chart values, expected to be a relative path in the SourceRef. Deprecated in favor of ValuesFiles, for backwards compatibility the file specified here is merged before the ValuesFiles items. Ignored when omitted.
                   type: string
-                type:
-                  description: Type of the HelmRepository. When this field is set to  "oci", the URL field value must be prefixed with "oci://".
-                  enum:
-                    - default
-                    - oci
-                  type: string
-                url:
-                  description: URL of the Helm repository, a valid URL contains at least a protocol and host.
+                valuesFiles:
+                  description: ValuesFiles is an alternative list of values files to use as the chart values (values.yaml is not included by default), expected to be a relative path in the SourceRef. Values files are merged in the order of this list with the last file overriding the first. Ignored when omitted.
+                  items:
+                    type: string
+                  type: array
+                version:
+                  default: '*'
+                  description: Version is the chart version semver expression, ignored for charts from GitRepository and Bucket sources. Defaults to latest when omitted.
                   type: string
               required:
+                - chart
                 - interval
-                - url
+                - sourceRef
               type: object
             status:
               default:
                 observedGeneration: -1
-              description: HelmRepositoryStatus records the observed state of the HelmRepository.
+              description: HelmChartStatus records the observed state of the HelmChart.
               properties:
                 artifact:
-                  description: Artifact represents the last successful HelmRepository reconciliation.
+                  description: Artifact represents the output of the last successful reconciliation.
                   properties:
                     checksum:
                       description: Checksum is the SHA256 checksum of the Artifact file.
@@ -298,7 +363,7 @@ spec:
                     - url
                   type: object
                 conditions:
-                  description: Conditions holds the conditions for the HelmRepository.
+                  description: Conditions holds the conditions for the HelmChart.
                   items:
                     description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
                     properties:
@@ -344,12 +409,18 @@ spec:
                 lastHandledReconcileAt:
                   description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change of the annotation value can be detected.
                   type: string
+                observedChartName:
+                  description: ObservedChartName is the last observed chart name as specified by the resolved chart reference.
+                  type: string
                 observedGeneration:
-                  description: ObservedGeneration is the last observed generation of the HelmRepository object.
+                  description: ObservedGeneration is the last observed generation of the HelmChart object.
                   format: int64
                   type: integer
+                observedSourceArtifactRevision:
+                  description: ObservedSourceArtifactRevision is the last observed Artifact.Revision of the HelmChartSpec.SourceRef.
+                  type: string
                 url:
-                  description: URL is the dynamic fetch link for the latest Artifact. It is provided on a "best effort" basis, and using the precise HelmRepositoryStatus.Artifact data is recommended.
+                  description: URL is the dynamic fetch link for the latest Artifact. It is provided on a "best effort" basis, and using the precise BucketStatus.Artifact data is recommended.
                   type: string
               type: object
           type: object

--- a/helm/flux-app/crd-base/helmrelease.yaml
+++ b/helm/flux-app/crd-base/helmrelease.yaml
@@ -5,8 +5,13 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+    app.kubernetes.io/name: '{{ include "name" . }}'
     app.kubernetes.io/part-of: flux
+    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
     giantswarm.io/service_type: managed
+    helm.sh/chart: '{{ include "chart" . }}'
   name: helmreleases.helm.toolkit.fluxcd.io
 spec:
   group: helm.toolkit.fluxcd.io

--- a/helm/flux-app/crd-base/helmrepository.yaml
+++ b/helm/flux-app/crd-base/helmrepository.yaml
@@ -5,21 +5,28 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+    app.kubernetes.io/name: '{{ include "name" . }}'
     app.kubernetes.io/part-of: flux
+    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
     giantswarm.io/service_type: managed
-  name: buckets.source.toolkit.fluxcd.io
+    helm.sh/chart: '{{ include "chart" . }}'
+  name: helmrepositories.source.toolkit.fluxcd.io
 spec:
   group: source.toolkit.fluxcd.io
   names:
-    kind: Bucket
-    listKind: BucketList
-    plural: buckets
-    singular: bucket
+    kind: HelmRepository
+    listKind: HelmRepositoryList
+    plural: helmrepositories
+    shortNames:
+      - helmrepo
+    singular: helmrepository
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
-        - jsonPath: .spec.endpoint
-          name: Endpoint
+        - jsonPath: .spec.url
+          name: URL
           type: string
         - jsonPath: .status.conditions[?(@.type=="Ready")].status
           name: Ready
@@ -33,7 +40,7 @@ spec:
       name: v1beta1
       schema:
         openAPIV3Schema:
-          description: Bucket is the Schema for the buckets API
+          description: HelmRepository is the Schema for the helmrepositories API
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -44,7 +51,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: BucketSpec defines the desired state of an S3 compatible bucket
+              description: HelmRepositorySpec defines the reference to a Helm repository.
               properties:
                 accessFrom:
                   description: AccessFrom defines an Access Control List for allowing cross-namespace references to this object.
@@ -64,34 +71,14 @@ spec:
                   required:
                     - namespaceSelectors
                   type: object
-                bucketName:
-                  description: The bucket name.
-                  type: string
-                endpoint:
-                  description: The bucket endpoint address.
-                  type: string
-                ignore:
-                  description: Ignore overrides the set of excluded patterns in the .sourceignore format (which is the same as .gitignore). If not provided, a default will be used, consult the documentation for your version to find out what those are.
-                  type: string
-                insecure:
-                  description: Insecure allows connecting to a non-TLS S3 HTTP endpoint.
-                  type: boolean
                 interval:
-                  description: The interval at which to check for bucket updates.
+                  description: The interval at which to check the upstream for updates.
                   type: string
-                provider:
-                  default: generic
-                  description: The S3 compatible storage provider name, default ('generic').
-                  enum:
-                    - generic
-                    - aws
-                    - gcp
-                  type: string
-                region:
-                  description: The bucket region.
-                  type: string
+                passCredentials:
+                  description: PassCredentials allows the credentials from the SecretRef to be passed on to a host that does not match the host as defined in URL. This may be required if the host of the advertised chart URLs in the index differ from the defined URL. Enabling this should be done with caution, as it can potentially result in credentials getting stolen in a MITM-attack.
+                  type: boolean
                 secretRef:
-                  description: The name of the secret containing authentication credentials for the Bucket.
+                  description: The name of the secret containing authentication credentials for the Helm repository. For HTTP/S basic auth the secret must contain username and password fields. For TLS the secret must contain a certFile and keyFile, and/or caCert fields.
                   properties:
                     name:
                       description: Name of the referent.
@@ -104,20 +91,22 @@ spec:
                   type: boolean
                 timeout:
                   default: 60s
-                  description: The timeout for download operations, defaults to 60s.
+                  description: The timeout of index downloading, defaults to 60s.
+                  type: string
+                url:
+                  description: The Helm repository URL, a valid URL contains at least a protocol and host.
                   type: string
               required:
-                - bucketName
-                - endpoint
                 - interval
+                - url
               type: object
             status:
               default:
                 observedGeneration: -1
-              description: BucketStatus defines the observed state of a bucket
+              description: HelmRepositoryStatus defines the observed state of the HelmRepository.
               properties:
                 artifact:
-                  description: Artifact represents the output of the last successful Bucket sync.
+                  description: Artifact represents the output of the last successful repository sync.
                   properties:
                     checksum:
                       description: Checksum is the SHA256 checksum of the artifact.
@@ -140,7 +129,7 @@ spec:
                     - url
                   type: object
                 conditions:
-                  description: Conditions holds the conditions for the Bucket.
+                  description: Conditions holds the conditions for the HelmRepository.
                   items:
                     description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
                     properties:
@@ -191,7 +180,7 @@ spec:
                   format: int64
                   type: integer
                 url:
-                  description: URL is the download link for the artifact output of the last Bucket sync.
+                  description: URL is the download link for the last index fetched.
                   type: string
               type: object
           type: object
@@ -200,8 +189,8 @@ spec:
       subresources:
         status: {}
     - additionalPrinterColumns:
-        - jsonPath: .spec.endpoint
-          name: Endpoint
+        - jsonPath: .spec.url
+          name: URL
           type: string
         - jsonPath: .metadata.creationTimestamp
           name: Age
@@ -215,7 +204,7 @@ spec:
       name: v1beta2
       schema:
         openAPIV3Schema:
-          description: Bucket is the Schema for the buckets API.
+          description: HelmRepository is the Schema for the helmrepositories API.
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -226,7 +215,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: BucketSpec specifies the required configuration to produce an Artifact for an object storage bucket.
+              description: HelmRepositorySpec specifies the required configuration to produce an Artifact for a Helm repository index YAML.
               properties:
                 accessFrom:
                   description: 'AccessFrom specifies an Access Control List for allowing cross-namespace references to this object. NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092'
@@ -246,35 +235,14 @@ spec:
                   required:
                     - namespaceSelectors
                   type: object
-                bucketName:
-                  description: BucketName is the name of the object storage bucket.
-                  type: string
-                endpoint:
-                  description: Endpoint is the object storage address the BucketName is located at.
-                  type: string
-                ignore:
-                  description: Ignore overrides the set of excluded patterns in the .sourceignore format (which is the same as .gitignore). If not provided, a default will be used, consult the documentation for your version to find out what those are.
-                  type: string
-                insecure:
-                  description: Insecure allows connecting to a non-TLS HTTP Endpoint.
-                  type: boolean
                 interval:
-                  description: Interval at which to check the Endpoint for updates.
+                  description: Interval at which to check the URL for updates.
                   type: string
-                provider:
-                  default: generic
-                  description: Provider of the object storage bucket. Defaults to 'generic', which expects an S3 (API) compatible object storage.
-                  enum:
-                    - generic
-                    - aws
-                    - gcp
-                    - azure
-                  type: string
-                region:
-                  description: Region of the Endpoint where the BucketName is located in.
-                  type: string
+                passCredentials:
+                  description: PassCredentials allows the credentials from the SecretRef to be passed on to a host that does not match the host as defined in URL. This may be required if the host of the advertised chart URLs in the index differ from the defined URL. Enabling this should be done with caution, as it can potentially result in credentials getting stolen in a MITM-attack.
+                  type: boolean
                 secretRef:
-                  description: SecretRef specifies the Secret containing authentication credentials for the Bucket.
+                  description: SecretRef specifies the Secret containing authentication credentials for the HelmRepository. For HTTP/S basic auth the secret must contain 'username' and 'password' fields. For TLS the secret must contain a 'certFile' and 'keyFile', and/or 'caCert' fields.
                   properties:
                     name:
                       description: Name of the referent.
@@ -283,24 +251,32 @@ spec:
                     - name
                   type: object
                 suspend:
-                  description: Suspend tells the controller to suspend the reconciliation of this Bucket.
+                  description: Suspend tells the controller to suspend the reconciliation of this HelmRepository.
                   type: boolean
                 timeout:
                   default: 60s
-                  description: Timeout for fetch operations, defaults to 60s.
+                  description: Timeout of the index fetch operation, defaults to 60s.
+                  type: string
+                type:
+                  description: Type of the HelmRepository. When this field is set to  "oci", the URL field value must be prefixed with "oci://".
+                  enum:
+                    - default
+                    - oci
+                  type: string
+                url:
+                  description: URL of the Helm repository, a valid URL contains at least a protocol and host.
                   type: string
               required:
-                - bucketName
-                - endpoint
                 - interval
+                - url
               type: object
             status:
               default:
                 observedGeneration: -1
-              description: BucketStatus records the observed state of a Bucket.
+              description: HelmRepositoryStatus records the observed state of the HelmRepository.
               properties:
                 artifact:
-                  description: Artifact represents the last successful Bucket reconciliation.
+                  description: Artifact represents the last successful HelmRepository reconciliation.
                   properties:
                     checksum:
                       description: Checksum is the SHA256 checksum of the Artifact file.
@@ -327,7 +303,7 @@ spec:
                     - url
                   type: object
                 conditions:
-                  description: Conditions holds the conditions for the Bucket.
+                  description: Conditions holds the conditions for the HelmRepository.
                   items:
                     description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
                     properties:
@@ -374,11 +350,11 @@ spec:
                   description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change of the annotation value can be detected.
                   type: string
                 observedGeneration:
-                  description: ObservedGeneration is the last observed generation of the Bucket object.
+                  description: ObservedGeneration is the last observed generation of the HelmRepository object.
                   format: int64
                   type: integer
                 url:
-                  description: URL is the dynamic fetch link for the latest Artifact. It is provided on a "best effort" basis, and using the precise BucketStatus.Artifact data is recommended.
+                  description: URL is the dynamic fetch link for the latest Artifact. It is provided on a "best effort" basis, and using the precise HelmRepositoryStatus.Artifact data is recommended.
                   type: string
               type: object
           type: object

--- a/helm/flux-app/crd-base/imagepolicy.yaml
+++ b/helm/flux-app/crd-base/imagepolicy.yaml
@@ -5,8 +5,13 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+    app.kubernetes.io/name: '{{ include "name" . }}'
     app.kubernetes.io/part-of: flux
+    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
     giantswarm.io/service_type: managed
+    helm.sh/chart: '{{ include "chart" . }}'
   name: imagepolicies.image.toolkit.fluxcd.io
 spec:
   group: image.toolkit.fluxcd.io

--- a/helm/flux-app/crd-base/imagerepository.yaml
+++ b/helm/flux-app/crd-base/imagerepository.yaml
@@ -5,8 +5,13 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+    app.kubernetes.io/name: '{{ include "name" . }}'
     app.kubernetes.io/part-of: flux
+    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
     giantswarm.io/service_type: managed
+    helm.sh/chart: '{{ include "chart" . }}'
   name: imagerepositories.image.toolkit.fluxcd.io
 spec:
   group: image.toolkit.fluxcd.io

--- a/helm/flux-app/crd-base/imageupdateautomation.yaml
+++ b/helm/flux-app/crd-base/imageupdateautomation.yaml
@@ -5,8 +5,13 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+    app.kubernetes.io/name: '{{ include "name" . }}'
     app.kubernetes.io/part-of: flux
+    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
     giantswarm.io/service_type: managed
+    helm.sh/chart: '{{ include "chart" . }}'
   name: imageupdateautomations.image.toolkit.fluxcd.io
 spec:
   group: image.toolkit.fluxcd.io

--- a/helm/flux-app/crd-base/kustomization.yaml
+++ b/helm/flux-app/crd-base/kustomization.yaml
@@ -5,8 +5,13 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+    app.kubernetes.io/name: '{{ include "name" . }}'
     app.kubernetes.io/part-of: flux
+    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
     giantswarm.io/service_type: managed
+    helm.sh/chart: '{{ include "chart" . }}'
   name: kustomizations.kustomize.toolkit.fluxcd.io
 spec:
   group: kustomize.toolkit.fluxcd.io

--- a/helm/flux-app/crd-base/provider.yaml
+++ b/helm/flux-app/crd-base/provider.yaml
@@ -5,16 +5,21 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+    app.kubernetes.io/name: '{{ include "name" . }}'
     app.kubernetes.io/part-of: flux
+    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
     giantswarm.io/service_type: managed
-  name: receivers.notification.toolkit.fluxcd.io
+    helm.sh/chart: '{{ include "chart" . }}'
+  name: providers.notification.toolkit.fluxcd.io
 spec:
   group: notification.toolkit.fluxcd.io
   names:
-    kind: Receiver
-    listKind: ReceiverList
-    plural: receivers
-    singular: receiver
+    kind: Provider
+    listKind: ProviderList
+    plural: providers
+    singular: provider
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
@@ -30,7 +35,7 @@ spec:
       name: v1beta1
       schema:
         openAPIV3Schema:
-          description: Receiver is the Schema for the receivers API
+          description: Provider is the Schema for the providers API
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -41,55 +46,30 @@ spec:
             metadata:
               type: object
             spec:
-              description: ReceiverSpec defines the desired state of Receiver
+              description: ProviderSpec defines the desired state of Provider
               properties:
-                events:
-                  description: A list of events to handle, e.g. 'push' for GitHub or 'Push Hook' for GitLab.
-                  items:
-                    type: string
-                  type: array
-                resources:
-                  description: A list of resources to be notified about changes.
-                  items:
-                    description: CrossNamespaceObjectReference contains enough information to let you locate the typed referenced object at cluster level
-                    properties:
-                      apiVersion:
-                        description: API version of the referent
-                        type: string
-                      kind:
-                        description: Kind of the referent
-                        enum:
-                          - Bucket
-                          - GitRepository
-                          - Kustomization
-                          - HelmRelease
-                          - HelmChart
-                          - HelmRepository
-                          - ImageRepository
-                          - ImagePolicy
-                          - ImageUpdateAutomation
-                        type: string
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                        type: object
-                      name:
-                        description: Name of the referent
-                        maxLength: 53
-                        minLength: 1
-                        type: string
-                      namespace:
-                        description: Namespace of the referent
-                        maxLength: 53
-                        minLength: 1
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
+                address:
+                  description: HTTP/S webhook address of this provider
+                  pattern: ^(http|https)://
+                  type: string
+                certSecretRef:
+                  description: CertSecretRef can be given the name of a secret containing a PEM-encoded CA certificate (`caFile`)
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                channel:
+                  description: Alert channel for this provider
+                  type: string
+                proxy:
+                  description: HTTP/S address of the proxy
+                  pattern: ^(http|https)://
+                  type: string
                 secretRef:
-                  description: Secret reference containing the token used to validate the payload authenticity
+                  description: Secret reference containing the provider webhook URL using "address" as data key
                   properties:
                     name:
                       description: Name of the referent.
@@ -101,28 +81,39 @@ spec:
                   description: This flag tells the controller to suspend subsequent events handling. Defaults to false.
                   type: boolean
                 type:
-                  description: Type of webhook sender, used to determine the validation procedure and payload deserialization.
+                  description: Type of provider
                   enum:
+                    - slack
+                    - discord
+                    - msteams
+                    - rocket
                     - generic
-                    - generic-hmac
                     - github
                     - gitlab
                     - bitbucket
-                    - harbor
-                    - dockerhub
-                    - quay
-                    - gcr
-                    - nexus
-                    - acr
+                    - azuredevops
+                    - googlechat
+                    - webex
+                    - sentry
+                    - azureeventhub
+                    - telegram
+                    - lark
+                    - matrix
+                    - opsgenie
+                    - alertmanager
+                    - grafana
+                    - githubdispatch
+                  type: string
+                username:
+                  description: Bot username for this provider
                   type: string
               required:
-                - resources
                 - type
               type: object
             status:
               default:
                 observedGeneration: -1
-              description: ReceiverStatus defines the observed state of Receiver
+              description: ProviderStatus defines the observed state of Provider
               properties:
                 conditions:
                   items:
@@ -168,12 +159,9 @@ spec:
                     type: object
                   type: array
                 observedGeneration:
-                  description: ObservedGeneration is the last observed generation.
+                  description: ObservedGeneration is the last reconciled generation.
                   format: int64
                   type: integer
-                url:
-                  description: Generated webhook URL in the format of '/hook/sha256sum(token+name+namespace)'.
-                  type: string
               type: object
           type: object
       served: true

--- a/helm/flux-app/crd-base/receiver.yaml
+++ b/helm/flux-app/crd-base/receiver.yaml
@@ -5,16 +5,21 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+    app.kubernetes.io/name: '{{ include "name" . }}'
     app.kubernetes.io/part-of: flux
+    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
     giantswarm.io/service_type: managed
-  name: providers.notification.toolkit.fluxcd.io
+    helm.sh/chart: '{{ include "chart" . }}'
+  name: receivers.notification.toolkit.fluxcd.io
 spec:
   group: notification.toolkit.fluxcd.io
   names:
-    kind: Provider
-    listKind: ProviderList
-    plural: providers
-    singular: provider
+    kind: Receiver
+    listKind: ReceiverList
+    plural: receivers
+    singular: receiver
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
@@ -30,7 +35,7 @@ spec:
       name: v1beta1
       schema:
         openAPIV3Schema:
-          description: Provider is the Schema for the providers API
+          description: Receiver is the Schema for the receivers API
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -41,30 +46,55 @@ spec:
             metadata:
               type: object
             spec:
-              description: ProviderSpec defines the desired state of Provider
+              description: ReceiverSpec defines the desired state of Receiver
               properties:
-                address:
-                  description: HTTP/S webhook address of this provider
-                  pattern: ^(http|https)://
-                  type: string
-                certSecretRef:
-                  description: CertSecretRef can be given the name of a secret containing a PEM-encoded CA certificate (`caFile`)
-                  properties:
-                    name:
-                      description: Name of the referent.
-                      type: string
-                  required:
-                    - name
-                  type: object
-                channel:
-                  description: Alert channel for this provider
-                  type: string
-                proxy:
-                  description: HTTP/S address of the proxy
-                  pattern: ^(http|https)://
-                  type: string
+                events:
+                  description: A list of events to handle, e.g. 'push' for GitHub or 'Push Hook' for GitLab.
+                  items:
+                    type: string
+                  type: array
+                resources:
+                  description: A list of resources to be notified about changes.
+                  items:
+                    description: CrossNamespaceObjectReference contains enough information to let you locate the typed referenced object at cluster level
+                    properties:
+                      apiVersion:
+                        description: API version of the referent
+                        type: string
+                      kind:
+                        description: Kind of the referent
+                        enum:
+                          - Bucket
+                          - GitRepository
+                          - Kustomization
+                          - HelmRelease
+                          - HelmChart
+                          - HelmRepository
+                          - ImageRepository
+                          - ImagePolicy
+                          - ImageUpdateAutomation
+                        type: string
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                      name:
+                        description: Name of the referent
+                        maxLength: 53
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: Namespace of the referent
+                        maxLength: 53
+                        minLength: 1
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
                 secretRef:
-                  description: Secret reference containing the provider webhook URL using "address" as data key
+                  description: Secret reference containing the token used to validate the payload authenticity
                   properties:
                     name:
                       description: Name of the referent.
@@ -76,39 +106,28 @@ spec:
                   description: This flag tells the controller to suspend subsequent events handling. Defaults to false.
                   type: boolean
                 type:
-                  description: Type of provider
+                  description: Type of webhook sender, used to determine the validation procedure and payload deserialization.
                   enum:
-                    - slack
-                    - discord
-                    - msteams
-                    - rocket
                     - generic
+                    - generic-hmac
                     - github
                     - gitlab
                     - bitbucket
-                    - azuredevops
-                    - googlechat
-                    - webex
-                    - sentry
-                    - azureeventhub
-                    - telegram
-                    - lark
-                    - matrix
-                    - opsgenie
-                    - alertmanager
-                    - grafana
-                    - githubdispatch
-                  type: string
-                username:
-                  description: Bot username for this provider
+                    - harbor
+                    - dockerhub
+                    - quay
+                    - gcr
+                    - nexus
+                    - acr
                   type: string
               required:
+                - resources
                 - type
               type: object
             status:
               default:
                 observedGeneration: -1
-              description: ProviderStatus defines the observed state of Provider
+              description: ReceiverStatus defines the observed state of Receiver
               properties:
                 conditions:
                   items:
@@ -154,9 +173,12 @@ spec:
                     type: object
                   type: array
                 observedGeneration:
-                  description: ObservedGeneration is the last reconciled generation.
+                  description: ObservedGeneration is the last observed generation.
                   format: int64
                   type: integer
+                url:
+                  description: Generated webhook URL in the format of '/hook/sha256sum(token+name+namespace)'.
+                  type: string
               type: object
           type: object
       served: true

--- a/helm/flux-app/templates/_helpers.tpl
+++ b/helm/flux-app/templates/_helpers.tpl
@@ -31,6 +31,12 @@ app.kubernetes.io/name: {{ include "name" . | quote }}
 app.kubernetes.io/instance: {{ .Release.Name | quote }}
 {{- end -}}
 
+{{/*
+CRD Installation
+
+Flux CRDs are installed first by a job.
+*/}}
+
 {{- define "crdInstall" -}}
 {{- printf "%s-%s" ( include "name" . ) "crd-install" | replace "+" "_" | trimSuffix "-" -}}
 {{- end -}}
@@ -47,6 +53,30 @@ app.kubernetes.io/instance: {{ .Release.Name | quote }}
 {{/* Create a label which can be used to select any orphaned crd-install hook resources */}}
 {{- define "crdInstallSelector" -}}
 {{- printf "%s" "crd-install-hook" -}}
+{{- end -}}
+
+{{/*
+CR Installation
+
+Flux CRs are installed after Flux CRDs by a job.
+*/}}
+
+{{- define "crInstall" -}}
+{{- printf "%s-%s" ( include "name" . ) "cr-install" | replace "+" "_" | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "crInstallJob" -}}
+{{- printf "%s-%s-%s" ( include "name" . ) "cr-install" .Chart.AppVersion | replace "+" "_" | replace "." "-" | trimSuffix "-" | trunc 63 -}}
+{{- end -}}
+
+{{- define "crInstallAnnotations" -}}
+"helm.sh/hook": "pre-install,pre-upgrade"
+"helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+{{- end -}}
+
+{{/* Create a label which can be used to select any orphaned cr-install hook resources */}}
+{{- define "crInstallSelector" -}}
+{{- printf "%s" "cr-install-hook" -}}
 {{- end -}}
 
 {{/* Usage:

--- a/helm/flux-app/templates/cr-install/cr-job.yaml
+++ b/helm/flux-app/templates/cr-install/cr-job.yaml
@@ -1,0 +1,76 @@
+{{- if gt (add (len .Values.sources) (len .Values.kustomizations)) 0 -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "crInstallJob" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "15"
+    {{- include "crInstallAnnotations" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "crInstall" . | quote }}
+    {{- include "labels.selector" . | nindent 4 }}
+    role: {{ include "crInstallSelector" . | quote }}
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: {{ include "crInstall" . | quote }}
+        {{- include "labels.selector" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "crInstall" . }}
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 2000
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: kubectl
+        image: "{{ .Values.images.registry }}/giantswarm/docker-kubectl:1.23.6"
+        command:
+        - sh
+        - -c
+        - |
+          set -o errexit ; set -o xtrace ; set -o nounset
+
+          # piping stderr to stdout means kubectl's errors are surfaced
+          # in the pod's logs.
+
+          kubectl apply -f /data/ 2>&1
+        securityContext:
+          readOnlyRootFilesystem: true
+        volumeMounts:
+{{ $globalScope := . }}
+{{- range .Values.sources }}
+        - name: {{ include "crInstall" $globalScope }}-source-{{ .name }}
+          mountPath: "/data/sources.{{ .name }}.yaml"
+          subPath: "sources.{{ .name }}.yaml"
+{{- end }}
+{{- range .Values.kustomizations }}
+        - name: {{ include "crInstall" $globalScope }}-kustomization-{{ .name }}
+          mountPath: "/data/kustomizations.{{ .name }}.yaml"
+          subPath: "kustomizations.{{ .name }}.yaml"
+{{- end }}
+        resources: {{- toYaml .Values.crds.resources | nindent 10 }}
+      volumes:
+{{- range .Values.sources }}
+      - name: {{ include "crInstall" $globalScope }}-source-{{ .name }}
+        configMap:
+          name: {{ include "crInstall" $globalScope }}-source-{{ .name }}
+          items:
+          - key: content
+            path: "kustomizations.{{ .name }}.yaml"
+{{- end }}
+{{- range .Values.kustomizations }}
+      - name: {{ include "crInstall" $globalScope }}-kustomization-{{ .name }}
+        configMap:
+          name: {{ include "crInstall" $globalScope }}-kustomization-{{ .name }}
+          items:
+            - key: content
+              path: "kustomizations.{{ .name }}.yaml"
+{{- end }}
+      restartPolicy: Never
+  backoffLimit: 4
+{{- end }}

--- a/helm/flux-app/templates/cr-install/cr-job.yaml
+++ b/helm/flux-app/templates/cr-install/cr-job.yaml
@@ -61,7 +61,7 @@ spec:
           name: {{ include "crInstall" $globalScope }}-source-{{ .name }}
           items:
           - key: content
-            path: "kustomizations.{{ .name }}.yaml"
+            path: "sources.{{ .name }}.yaml"
 {{- end }}
 {{- range .Values.kustomizations }}
       - name: {{ include "crInstall" $globalScope }}-kustomization-{{ .name }}

--- a/helm/flux-app/templates/cr-install/cr-kustomizations.yaml
+++ b/helm/flux-app/templates/cr-install/cr-kustomizations.yaml
@@ -27,18 +27,18 @@ data:
       interval: "{{ .interval }}"
       path: "{{ .path }}"
       {{- if .postBuild }}
-    postBuild:
-      {{- .postBuild | toYaml | nindent 6 }}
+      postBuild:
+        {{- .postBuild | toYaml | nindent 6 }}
       {{- end }}
-    prune: {{ .prune }}
-    sourceRef:
-      kind: GitRepository
-      name: "{{ .source_name }}"
+      prune: {{ .prune }}
+      sourceRef:
+        kind: GitRepository
+        name: "{{ .source_name }}"
       {{- if $globalScope.Values.sopsEncryption.enabled }}
-    decryption:
-      provider: sops
-      secretRef:
-        name: "{{ $globalScope.Release.Name }}-sops-gpg"
+      decryption:
+        provider: sops
+        secretRef:
+          name: "{{ $globalScope.Release.Name }}-sops-gpg"
       {{- end }}
     ---
     apiVersion: notification.toolkit.fluxcd.io/v1beta1
@@ -51,7 +51,7 @@ data:
         name: "{{ .source_name }}-github-notification-provider"
       eventSeverity: info
       eventSources:
-        - kind: Kustomization
-          name: "{{ .name }}"
-          namespace: "{{ $globalScope.Release.Namespace }}"
+      - kind: Kustomization
+        name: "{{ .name }}"
+        namespace: "{{ $globalScope.Release.Namespace }}"
 {{- end }}

--- a/helm/flux-app/templates/cr-install/cr-kustomizations.yaml
+++ b/helm/flux-app/templates/cr-install/cr-kustomizations.yaml
@@ -28,7 +28,7 @@ data:
       path: "{{ .path }}"
       {{- if .postBuild }}
       postBuild:
-        {{- .postBuild | toYaml | nindent 6 }}
+        {{- .postBuild | toYaml | nindent 8 }}
       {{- end }}
       prune: {{ .prune }}
       sourceRef:

--- a/helm/flux-app/templates/cr-install/cr-kustomizations.yaml
+++ b/helm/flux-app/templates/cr-install/cr-kustomizations.yaml
@@ -1,0 +1,59 @@
+{{ $globalScope := . }}
+{{- range .Values.kustomizations }}
+  {{- with $globalScope }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "crInstall" . }}-kustomization-{{ .name }}
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    # TODO
+    "helm.sh/hook-weight": "7"
+    {{- include "crInstallAnnotations" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "crInstall" . | quote }}
+    {{- include "labels.selector" . | nindent 4 }}
+    role: {{ include "crInstallSelector" . | quote }}
+  {{- end }}
+data:
+  content: |
+    ---
+    apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+    kind: Kustomization
+    metadata:
+      name: "{{ .name }}"
+      namespace: "{{ $.Release.Namespace }}"
+    spec:
+      interval: "{{ .interval }}"
+      path: "{{ .path }}"
+      {{- if .postBuild }}
+    postBuild:
+      {{- .postBuild | toYaml | nindent 6 }}
+      {{- end }}
+    prune: {{ .prune }}
+    sourceRef:
+      kind: GitRepository
+      name: "{{ .source_name }}"
+      {{- if $.Values.sopsEncryption.enabled }}
+    decryption:
+      provider: sops
+      secretRef:
+        name: "{{ $.Release.Name }}-sops-gpg"
+      {{- end }}
+    ---
+    apiVersion: notification.toolkit.fluxcd.io/v1beta1
+    kind: Alert
+    metadata:
+      name: "{{ .name }}-github-alert"
+      namespace: "{{ $.Release.Namespace }}"
+    spec:
+      providerRef:
+        name: "{{ .source_name }}-github-notification-provider"
+      eventSeverity: info
+      eventSources:
+        - kind: Kustomization
+          name: "{{ .name }}"
+          namespace: "{{ $.Release.Namespace }}"
+{{- end }}

--- a/helm/flux-app/templates/cr-install/cr-kustomizations.yaml
+++ b/helm/flux-app/templates/cr-install/cr-kustomizations.yaml
@@ -1,22 +1,20 @@
 {{ $globalScope := . }}
 {{- range .Values.kustomizations }}
-  {{- with $globalScope }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "crInstall" . }}-kustomization-{{ .name }}
-  namespace: {{ .Release.Namespace | quote }}
+  name: {{ include "crInstall" $globalScope }}-kustomization-{{ .name }}
+  namespace: {{ $globalScope.Release.Namespace | quote }}
   annotations:
     # create hook dependencies in the right order
     # TODO
     "helm.sh/hook-weight": "7"
-    {{- include "crInstallAnnotations" . | nindent 4 }}
+    {{- include "crInstallAnnotations" $globalScope | nindent 4 }}
   labels:
-    app.kubernetes.io/component: {{ include "crInstall" . | quote }}
-    {{- include "labels.selector" . | nindent 4 }}
-    role: {{ include "crInstallSelector" . | quote }}
-  {{- end }}
+    app.kubernetes.io/component: {{ include "crInstall" $globalScope | quote }}
+    {{- include "labels.selector" $globalScope | nindent 4 }}
+    role: {{ include "crInstallSelector" $globalScope | quote }}
 data:
   content: |
     ---
@@ -24,7 +22,7 @@ data:
     kind: Kustomization
     metadata:
       name: "{{ .name }}"
-      namespace: "{{ $.Release.Namespace }}"
+      namespace: "{{ $globalScope.Release.Namespace }}"
     spec:
       interval: "{{ .interval }}"
       path: "{{ .path }}"
@@ -36,18 +34,18 @@ data:
     sourceRef:
       kind: GitRepository
       name: "{{ .source_name }}"
-      {{- if $.Values.sopsEncryption.enabled }}
+      {{- if $globalScope.Values.sopsEncryption.enabled }}
     decryption:
       provider: sops
       secretRef:
-        name: "{{ $.Release.Name }}-sops-gpg"
+        name: "{{ $globalScope.Release.Name }}-sops-gpg"
       {{- end }}
     ---
     apiVersion: notification.toolkit.fluxcd.io/v1beta1
     kind: Alert
     metadata:
       name: "{{ .name }}-github-alert"
-      namespace: "{{ $.Release.Namespace }}"
+      namespace: "{{ $globalScope.Release.Namespace }}"
     spec:
       providerRef:
         name: "{{ .source_name }}-github-notification-provider"
@@ -55,5 +53,5 @@ data:
       eventSources:
         - kind: Kustomization
           name: "{{ .name }}"
-          namespace: "{{ $.Release.Namespace }}"
+          namespace: "{{ $globalScope.Release.Namespace }}"
 {{- end }}

--- a/helm/flux-app/templates/cr-install/cr-np.yaml
+++ b/helm/flux-app/templates/cr-install/cr-np.yaml
@@ -1,0 +1,38 @@
+{{- if gt (add (len .Values.sources) (len .Values.kustomizations)) 0 -}}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ include "crInstall" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "1"
+    {{- include "crInstallAnnotations" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "crInstall" . | quote }}
+    {{- include "labels.selector" . | nindent 4 }}
+    role: {{ include "crInstallSelector" . | quote }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: {{ include "crInstall" . | quote }}
+      {{- include "labels.selector" . | nindent 6 }}
+  # allow egress traffic to the Kubernetes API
+  egress:
+  - ports:
+    - port: 443
+      protocol: TCP
+    # legacy port kept for compatibility
+    - port: 6443
+      protocol: TCP
+    to:
+    {{- range tuple "10.0.0.0/8" "172.16.0.0/12" "192.168.0.0/16" "100.64.0.0/10" }}
+    - ipBlock:
+        cidr: {{ . }}
+    {{- end }}
+  # deny ingress traffic
+  ingress: []
+  policyTypes:
+  - Egress
+  - Ingress
+{{- end }}

--- a/helm/flux-app/templates/cr-install/cr-psp.yaml
+++ b/helm/flux-app/templates/cr-install/cr-psp.yaml
@@ -1,0 +1,36 @@
+{{- if gt (add (len .Values.sources) (len .Values.kustomizations)) 0 -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "crInstall" . }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-6"
+    {{- include "crInstallAnnotations" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "crInstall" . | quote }}
+    {{- include "labels.selector" . | nindent 4 }}
+    role: {{ include "crInstallSelector" . | quote }}
+spec:
+  privileged: false
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  volumes:
+  - 'configMap'
+  hostPID: false
+  hostIPC: false
+  hostNetwork: false
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/helm/flux-app/templates/cr-install/cr-rbac.yaml
+++ b/helm/flux-app/templates/cr-install/cr-rbac.yaml
@@ -30,7 +30,7 @@ rules:
   - use
 # Required by Sources
 - apiGroups:
-  - source.toolkit.fluxcd.io/v1beta1
+  - source.toolkit.fluxcd.io
   resources:
   - gitrepositories
   verbs:
@@ -40,7 +40,7 @@ rules:
   - get
   - patch
 - apiGroups:
-  - notification.toolkit.fluxcd.io/v1beta1
+  - notification.toolkit.fluxcd.io
   resources:
   - providers
   verbs:
@@ -57,7 +57,7 @@ rules:
   - create
 # Required by Kustomizations
 - apiGroups:
-  - kustomize.toolkit.fluxcd.io/v1beta2
+  - kustomize.toolkit.fluxcd.io
   resources:
   - kustomizations
   verbs:
@@ -67,7 +67,7 @@ rules:
   - get
   - patch
 - apiGroups:
-  - notification.toolkit.fluxcd.io/v1beta1
+  - notification.toolkit.fluxcd.io
   resources:
   - alerts
   verbs:

--- a/helm/flux-app/templates/cr-install/cr-rbac.yaml
+++ b/helm/flux-app/templates/cr-install/cr-rbac.yaml
@@ -53,9 +53,6 @@ rules:
   - Secret
   verbs:
   - create
-  - delete
-  - get
-  - patch
 # Required by Kustomizations
 - apiGroups:
   - kustomize.toolkit.fluxcd.io/v1beta2

--- a/helm/flux-app/templates/cr-install/cr-rbac.yaml
+++ b/helm/flux-app/templates/cr-install/cr-rbac.yaml
@@ -1,6 +1,6 @@
 {{- if gt (add (len .Values.sources) (len .Values.kustomizations)) 0 -}}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: {{ include "crInstall" . }}
   namespace: {{ .Release.Namespace | quote }}
@@ -32,7 +32,7 @@ rules:
 - apiGroups:
   - source.toolkit.fluxcd.io/v1beta1
   resources:
-  - gitRepositories
+  - gitrepositories
   verbs:
   - create
   - delete
@@ -78,7 +78,7 @@ rules:
   - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: {{ include "crInstall" . }}
   namespace: {{ .Release.Namespace | quote }}
@@ -92,7 +92,7 @@ metadata:
     role: {{ include "crInstallSelector" . | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: {{ include "crInstall" . }}
 subjects:
   - kind: ServiceAccount

--- a/helm/flux-app/templates/cr-install/cr-rbac.yaml
+++ b/helm/flux-app/templates/cr-install/cr-rbac.yaml
@@ -1,0 +1,100 @@
+{{- if .Values.crds.install }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "crInstall" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "2"
+    {{- include "crInstallAnnotations" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "crInstall" . | quote }}
+    {{- include "labels.selector" . | nindent 4 }}
+    role: {{ include "crInstallSelector" . | quote }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - {{ include "crInstall" . }}
+  verbs:
+  - use
+# Required by Sources
+- apiGroups:
+  - source.toolkit.fluxcd.io/v1beta1
+  resources:
+  - GitRepository
+  verbs:
+  - create
+  - delete
+  - get
+  - patch
+- apiGroups:
+  - notification.toolkit.fluxcd.io/v1beta1
+  resources:
+  - Provider
+  verbs:
+  - create
+  - delete
+  - get
+  - patch
+- apiGroups:
+  - v1
+  resources:
+  - Secret
+  verbs:
+  - create
+  - delete
+  - get
+  - patch
+# Required by Kustomizations
+- apiGroups:
+  - kustomize.toolkit.fluxcd.io/v1beta2
+  resources:
+  - Kustomization
+  verbs:
+  - create
+  - delete
+  - get
+  - patch
+- apiGroups:
+  - notification.toolkit.fluxcd.io/v1beta1
+  resources:
+  - Alert
+  verbs:
+  - create
+  - delete
+  - get
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "crInstall" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "3"
+    {{- include "crInstallAnnotations" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "crInstall" . | quote }}
+    {{- include "labels.common" . | nindent 4 }}
+    role: {{ include "crInstallSelector" . | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "crInstall" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "crInstall" . }}
+    namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/helm/flux-app/templates/cr-install/cr-rbac.yaml
+++ b/helm/flux-app/templates/cr-install/cr-rbac.yaml
@@ -50,11 +50,15 @@ rules:
   - get
   - patch
 - apiGroups:
-  - v1
+  - ""
   resources:
-  - Secret
+  - secrets
   verbs:
   - create
+  - delete
+  - list
+  - get
+  - patch
 # Required by Kustomizations
 - apiGroups:
   - kustomize.toolkit.fluxcd.io

--- a/helm/flux-app/templates/cr-install/cr-rbac.yaml
+++ b/helm/flux-app/templates/cr-install/cr-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.crds.install }}
+{{- if gt (add (len .Values.sources) (len .Values.kustomizations)) 0 -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -32,19 +32,21 @@ rules:
 - apiGroups:
   - source.toolkit.fluxcd.io/v1beta1
   resources:
-  - GitRepository
+  - gitRepositories
   verbs:
   - create
   - delete
+  - list
   - get
   - patch
 - apiGroups:
   - notification.toolkit.fluxcd.io/v1beta1
   resources:
-  - Provider
+  - providers
   verbs:
   - create
   - delete
+  - list
   - get
   - patch
 - apiGroups:
@@ -57,19 +59,21 @@ rules:
 - apiGroups:
   - kustomize.toolkit.fluxcd.io/v1beta2
   resources:
-  - Kustomization
+  - kustomizations
   verbs:
   - create
   - delete
+  - list
   - get
   - patch
 - apiGroups:
   - notification.toolkit.fluxcd.io/v1beta1
   resources:
-  - Alert
+  - alerts
   verbs:
   - create
   - delete
+  - list
   - get
   - patch
 ---

--- a/helm/flux-app/templates/cr-install/cr-serviceaccount.yaml
+++ b/helm/flux-app/templates/cr-install/cr-serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if gt (add (len .Values.sources) (len .Values.kustomizations)) 0 -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "crInstall" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "10"
+    {{- include "crInstallAnnotations" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "crInstall" . | quote }}
+    {{- include "labels.selector" . | nindent 4 }}
+    role: {{ include "crInstallSelector" . | quote }}
+{{- end }}

--- a/helm/flux-app/templates/cr-install/cr-sops-encryption.yaml
+++ b/helm/flux-app/templates/cr-install/cr-sops-encryption.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.sopsEncryption.enabled }}
+apiVersion: v1
+data:
+{{- range $index, $key := .Values.sopsEncryption.encryptionKeys }}
+  "sops-{{ $index }}.asc": "{{ $key | b64enc }}"
+{{- end }}
+kind: Secret
+metadata:
+  name: "{{ .Release.Name }}-sops-gpg"
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    # create hook dependencies in the right order
+    # TODO
+    "helm.sh/hook-weight": "5"
+      {{- include "crdInstallAnnotations" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "crInstall" . | quote }}
+    {{- include "labels.selector" . | nindent 4 }}
+    role: {{ include "crInstallSelector" . | quote }}
+---
+{{- end }}

--- a/helm/flux-app/templates/cr-install/cr-sources.yaml
+++ b/helm/flux-app/templates/cr-install/cr-sources.yaml
@@ -29,6 +29,7 @@ data:
         branch: "{{ .branch }}"
       secretRef:
         name: "{{ .name }}-credentials"
+        namespace: "{{ $globalScope.Release.Namespace }}"
       url: "{{ .url }}"
     ---
     apiVersion: v1

--- a/helm/flux-app/templates/cr-install/cr-sources.yaml
+++ b/helm/flux-app/templates/cr-install/cr-sources.yaml
@@ -1,23 +1,20 @@
 {{ $globalScope := . }}
 {{- range .Values.sources }}
-  {{- with $globalScope }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "crInstall" . }}-source-{{ .name }}
-  namespace: {{ .Release.Namespace | quote }}
+  name: {{ include "crInstall" $globalScope }}-source-{{ .name }}
+  namespace: {{ $globalScope.Release.Namespace | quote }}
   annotations:
     # create hook dependencies in the right order
     # TODO
     "helm.sh/hook-weight": "6"
-    foo: baz
-    {{- include "crInstallAnnotations" . | nindent 4 }}
+    {{- include "crInstallAnnotations" $globalScope | nindent 4 }}
   labels:
-    app.kubernetes.io/component: {{ include "crInstall" . | quote }}
-    {{- include "labels.selector" . | nindent 4 }}
-    role: {{ include "crInstallSelector" . | quote }}
-  {{- end }}
+    app.kubernetes.io/component: {{ include "crInstall" $globalScope | quote }}
+    {{- include "labels.selector" $globalScope | nindent 4 }}
+    role: {{ include "crInstallSelector" $globalScope | quote }}
 data:
   content: |
     ---
@@ -25,7 +22,7 @@ data:
     kind: GitRepository
     metadata:
       name: "{{ .name }}"
-      namespace: "{{ $.Release.Namespace }}"
+      namespace: "{{ $globalScope.Release.Namespace }}"
     spec:
       interval: "{{ .interval }}"
       ref:
@@ -38,7 +35,7 @@ data:
     kind: Secret
     metadata:
       name: "{{ .name }}-credentials"
-      namespace: "{{ $.Release.Namespace }}"
+      namespace: "{{ $globalScope.Release.Namespace }}"
     type: Opaque
     data:
       username: "{{ .credentials.username | b64enc }}"
@@ -49,7 +46,7 @@ data:
     kind: Provider
     metadata:
       name: "{{ .name }}-github-notification-provider"
-      namespace: "{{ $.Release.Namespace }}"
+      namespace: "{{ $globalScope.Release.Namespace }}"
     spec:
       type: {{ .provider }}
       address: "{{ .url | trimSuffix ".git" }}"

--- a/helm/flux-app/templates/cr-install/cr-sources.yaml
+++ b/helm/flux-app/templates/cr-install/cr-sources.yaml
@@ -1,0 +1,58 @@
+{{ $globalScope := . }}
+{{- range .Values.sources }}
+  {{- with $globalScope }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "crInstall" . }}-source-{{ .name }}
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    # TODO
+    "helm.sh/hook-weight": "6"
+    foo: baz
+    {{- include "crInstallAnnotations" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "crInstall" . | quote }}
+    {{- include "labels.selector" . | nindent 4 }}
+    role: {{ include "crInstallSelector" . | quote }}
+  {{- end }}
+data:
+  content: |
+    ---
+    apiVersion: source.toolkit.fluxcd.io/v1beta1
+    kind: GitRepository
+    metadata:
+      name: "{{ .name }}"
+      namespace: "{{ $.Release.Namespace }}"
+    spec:
+      interval: "{{ .interval }}"
+      ref:
+        branch: "{{ .branch }}"
+      secretRef:
+        name: "{{ .name }}-credentials"
+      url: "{{ .url }}"
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: "{{ .name }}-credentials"
+      namespace: "{{ $.Release.Namespace }}"
+    type: Opaque
+    data:
+      username: "{{ .credentials.username | b64enc }}"
+      password: "{{ .credentials.password | b64enc }}"
+      token: "{{ .credentials.password | b64enc }}"
+    ---
+    apiVersion: notification.toolkit.fluxcd.io/v1beta1
+    kind: Provider
+    metadata:
+      name: "{{ .name }}-github-notification-provider"
+      namespace: "{{ $.Release.Namespace }}"
+    spec:
+      type: {{ .provider }}
+      address: "{{ .url | trimSuffix ".git" }}"
+      secretRef:
+        name: "{{ .name }}-credentials"
+{{- end }}

--- a/helm/flux-app/templates/crd-install/crd-configmap.yaml
+++ b/helm/flux-app/templates/crd-install/crd-configmap.yaml
@@ -1,0 +1,28 @@
+{{/*
+We have to create individual configmaps for each CRD - they exceed the total
+allowed length for a configmap if they are combined.
+*/}}
+{{ $currentScope := . }}
+{{- if .Values.crds.install }}
+  {{- range $path, $_ := .Files.Glob "crd-base/**" }}
+    {{- with $currentScope }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "crdInstall" . }}-{{ $path | base | trimSuffix ".yaml" }}
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-5"
+    {{- include "crdInstallAnnotations" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "crdInstall" . | quote }}
+    {{- include "labels.selector" . | nindent 4 }}
+    role: {{ include "crdInstallSelector" . | quote }}
+data:
+  content: |
+{{ tpl (.Files.Get $path) . | indent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/flux-app/templates/crd-install/crd-job.yaml
+++ b/helm/flux-app/templates/crd-install/crd-job.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.crds.install }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "crdInstallJob" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-1"
+    {{- include "crdInstallAnnotations" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "crdInstall" . | quote }}
+    {{- include "labels.selector" . | nindent 4 }}
+    role: {{ include "crdInstallSelector" . | quote }}
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: {{ include "crdInstall" . | quote }}
+        {{- include "labels.selector" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "crdInstall" . }}
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 2000
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: kubectl
+        image: "{{ .Values.images.registry }}/giantswarm/docker-kubectl:1.23.6"
+        command:
+        - sh
+        - -c
+        - |
+          set -o errexit ; set -o xtrace ; set -o nounset
+
+          # piping stderr to stdout means kubectl's errors are surfaced
+          # in the pod's logs.
+
+          kubectl apply -f /data/ 2>&1
+        securityContext:
+          readOnlyRootFilesystem: true
+        volumeMounts:
+{{- range $path, $_ := .Files.Glob "crd-base/**" }}
+        - name: {{ $path | base | trimSuffix ".yaml" }}
+          mountPath: /data/{{ $path | base }}
+          subPath: {{ $path | base }}
+{{- end }}
+        resources: {{- toYaml .Values.crds.resources | nindent 10 }}
+      volumes:
+{{ $currentScope := . }}
+{{- range $path, $_ := .Files.Glob "crd-base/**" }}
+    {{- with $currentScope }}
+      - name: {{ $path | base | trimSuffix ".yaml" }}
+        configMap:
+          name: {{ include "crdInstall" . }}-{{ $path | base | trimSuffix ".yaml" }}
+          items:
+          - key: content
+            path: {{ $path | base }}
+{{- end }}
+{{- end }}
+      restartPolicy: Never
+  backoffLimit: 4
+{{- end }}

--- a/helm/flux-app/templates/crd-install/crd-np.yaml
+++ b/helm/flux-app/templates/crd-install/crd-np.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.crds.install }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ include "crdInstall" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-7"
+    {{- include "crdInstallAnnotations" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "crdInstall" . | quote }}
+    {{- include "labels.selector" . | nindent 4 }}
+    role: {{ include "crdInstallSelector" . | quote }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: {{ include "crdInstall" . | quote }}
+      {{- include "labels.selector" . | nindent 6 }}
+  # allow egress traffic to the Kubernetes API
+  egress:
+  - ports:
+    - port: 443
+      protocol: TCP
+    # legacy port kept for compatibility
+    - port: 6443
+      protocol: TCP
+    to:
+    {{- range tuple "10.0.0.0/8" "172.16.0.0/12" "192.168.0.0/16" "100.64.0.0/10" }}
+    - ipBlock:
+        cidr: {{ . }}
+    {{- end }}
+  # deny ingress traffic
+  ingress: []
+  policyTypes:
+  - Egress
+  - Ingress
+{{- end }}

--- a/helm/flux-app/templates/crd-install/crd-psp.yaml
+++ b/helm/flux-app/templates/crd-install/crd-psp.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.crds.install }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "crdInstall" . }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-6"
+    {{- include "crdInstallAnnotations" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "crdInstall" . | quote }}
+    {{- include "labels.selector" . | nindent 4 }}
+    role: {{ include "crdInstallSelector" . | quote }}
+spec:
+  privileged: false
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  volumes:
+  - 'configMap'
+  hostPID: false
+  hostIPC: false
+  hostNetwork: false
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/helm/flux-app/templates/crd-install/crd-rbac.yaml
+++ b/helm/flux-app/templates/crd-install/crd-rbac.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.crds.install }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "crdInstall" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-3"
+    {{- include "crdInstallAnnotations" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "crdInstall" . | quote }}
+    {{- include "labels.selector" . | nindent 4 }}
+    role: {{ include "crdInstallSelector" . | quote }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - delete
+  - get
+  - patch
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - {{ include "crdInstall" . }}
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "crdInstall" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-2"
+    {{- include "crdInstallAnnotations" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "crdInstall" . | quote }}
+    {{- include "labels.common" . | nindent 4 }}
+    role: {{ include "crdInstallSelector" . | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "crdInstall" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "crdInstall" . }}
+    namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/helm/flux-app/templates/crd-install/crd-serviceaccount.yaml
+++ b/helm/flux-app/templates/crd-install/crd-serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.crds.install }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "crdInstall" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-4"
+    {{- include "crdInstallAnnotations" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "crdInstall" . | quote }}
+    {{- include "labels.selector" . | nindent 4 }}
+    role: {{ include "crdInstallSelector" . | quote }}
+{{- end }}

--- a/helm/flux-app/templates/source.yaml
+++ b/helm/flux-app/templates/source.yaml
@@ -1,88 +1,90 @@
-{{- if .Values.sopsEncryption.enabled }}
-apiVersion: v1
-data:
-{{- range $index, $key := .Values.sopsEncryption.encryptionKeys }}
-  "sops-{{ $index }}.asc": "{{ $key | b64enc }}"
-{{- end }}
-kind: Secret
-metadata:
-  name: "{{ .Release.Name }}-sops-gpg"
-  namespace: "{{ .Release.Namespace }}"
----
-{{- end }}
-{{- range .Values.sources }}
----
-apiVersion: source.toolkit.fluxcd.io/v1beta1
-kind: GitRepository
-metadata:
-  name: "{{ .name }}"
-  namespace: "{{ $.Release.Namespace }}"
-spec:
-  interval: "{{ .interval }}"
-  ref:
-    branch: "{{ .branch }}"
-  secretRef:
-    name: "{{ .name }}-credentials"
-  url: "{{ .url }}"
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "{{ .name }}-credentials"
-  namespace: "{{ $.Release.Namespace }}"
-type: Opaque
-data:
-  username: "{{ .credentials.username | b64enc }}"
-  password: "{{ .credentials.password | b64enc }}"
-  token: "{{ .credentials.password | b64enc }}"
----
-apiVersion: notification.toolkit.fluxcd.io/v1beta1
-kind: Provider
-metadata:
-  name: "{{ .name }}-github-notification-provider"
-  namespace: "{{ $.Release.Namespace }}"
-spec:
-  type: {{ .provider }}
-  address: "{{ .url | trimSuffix ".git" }}"
-  secretRef:
-    name: "{{ .name }}-credentials"
-{{- end }}
-{{- range .Values.kustomizations }}
----
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
-kind: Kustomization
-metadata:
-  name: "{{ .name }}"
-  namespace: "{{ $.Release.Namespace }}"
-spec:
-  interval: "{{ .interval }}"
-  path: "{{ .path }}"
-{{- if .postBuild }}
-  postBuild:
-{{- .postBuild | toYaml | nindent 4 }}
-{{- end }}
-  prune: {{ .prune }}
-  sourceRef:
-    kind: GitRepository
-    name: "{{ .source_name }}"
-{{- if $.Values.sopsEncryption.enabled }}
-  decryption:
-    provider: sops
-    secretRef:
-      name: "{{ $.Release.Name }}-sops-gpg"
-{{- end }}
----
-apiVersion: notification.toolkit.fluxcd.io/v1beta1
-kind: Alert
-metadata:
-  name: "{{ .name }}-github-alert"
-  namespace: "{{ $.Release.Namespace }}"
-spec:
-  providerRef:
-    name: "{{ .source_name }}-github-notification-provider"
-  eventSeverity: info
-  eventSources:
-    - kind: Kustomization
-      name: "{{ .name }}"
-      namespace: "{{ $.Release.Namespace }}"
-{{- end }}
+{{/*{{- if .Values.sopsEncryption.enabled }}*/}}
+{{/*apiVersion: v1*/}}
+{{/*data:*/}}
+{{/*{{- range $index, $key := .Values.sopsEncryption.encryptionKeys }}*/}}
+{{/*  "sops-{{ $index }}.asc": "{{ $key | b64enc }}"*/}}
+{{/*{{- end }}*/}}
+{{/*kind: Secret*/}}
+{{/*metadata:*/}}
+{{/*  name: "{{ .Release.Name }}-sops-gpg"*/}}
+{{/*  namespace: "{{ .Release.Namespace }}"*/}}
+{{/*---*/}}
+{{/*{{- end }}*/}}
+
+{{/*{{- range .Values.sources }}*/}}
+{{/*---*/}}
+{{/*apiVersion: source.toolkit.fluxcd.io/v1beta1*/}}
+{{/*kind: GitRepository*/}}
+{{/*metadata:*/}}
+{{/*  name: "{{ .name }}"*/}}
+{{/*  namespace: "{{ $.Release.Namespace }}"*/}}
+{{/*spec:*/}}
+{{/*  interval: "{{ .interval }}"*/}}
+{{/*  ref:*/}}
+{{/*    branch: "{{ .branch }}"*/}}
+{{/*  secretRef:*/}}
+{{/*    name: "{{ .name }}-credentials"*/}}
+{{/*  url: "{{ .url }}"*/}}
+{{/*---*/}}
+{{/*apiVersion: v1*/}}
+{{/*kind: Secret*/}}
+{{/*metadata:*/}}
+{{/*  name: "{{ .name }}-credentials"*/}}
+{{/*  namespace: "{{ $.Release.Namespace }}"*/}}
+{{/*type: Opaque*/}}
+{{/*data:*/}}
+{{/*  username: "{{ .credentials.username | b64enc }}"*/}}
+{{/*  password: "{{ .credentials.password | b64enc }}"*/}}
+{{/*  token: "{{ .credentials.password | b64enc }}"*/}}
+{{/*---*/}}
+{{/*apiVersion: notification.toolkit.fluxcd.io/v1beta1*/}}
+{{/*kind: Provider*/}}
+{{/*metadata:*/}}
+{{/*  name: "{{ .name }}-github-notification-provider"*/}}
+{{/*  namespace: "{{ $.Release.Namespace }}"*/}}
+{{/*spec:*/}}
+{{/*  type: {{ .provider }}*/}}
+{{/*  address: "{{ .url | trimSuffix ".git" }}"*/}}
+{{/*  secretRef:*/}}
+{{/*    name: "{{ .name }}-credentials"*/}}
+{{/*{{- end }}*/}}
+
+{{/*{{- range .Values.kustomizations }}*/}}
+{{/*---*/}}
+{{/*apiVersion: kustomize.toolkit.fluxcd.io/v1beta2*/}}
+{{/*kind: Kustomization*/}}
+{{/*metadata:*/}}
+{{/*  name: "{{ .name }}"*/}}
+{{/*  namespace: "{{ $.Release.Namespace }}"*/}}
+{{/*spec:*/}}
+{{/*  interval: "{{ .interval }}"*/}}
+{{/*  path: "{{ .path }}"*/}}
+{{/*{{- if .postBuild }}*/}}
+{{/*  postBuild:*/}}
+{{/*{{- .postBuild | toYaml | nindent 4 }}*/}}
+{{/*{{- end }}*/}}
+{{/*  prune: {{ .prune }}*/}}
+{{/*  sourceRef:*/}}
+{{/*    kind: GitRepository*/}}
+{{/*    name: "{{ .source_name }}"*/}}
+{{/*{{- if $.Values.sopsEncryption.enabled }}*/}}
+{{/*  decryption:*/}}
+{{/*    provider: sops*/}}
+{{/*    secretRef:*/}}
+{{/*      name: "{{ $.Release.Name }}-sops-gpg"*/}}
+{{/*{{- end }}*/}}
+{{/*---*/}}
+{{/*apiVersion: notification.toolkit.fluxcd.io/v1beta1*/}}
+{{/*kind: Alert*/}}
+{{/*metadata:*/}}
+{{/*  name: "{{ .name }}-github-alert"*/}}
+{{/*  namespace: "{{ $.Release.Namespace }}"*/}}
+{{/*spec:*/}}
+{{/*  providerRef:*/}}
+{{/*    name: "{{ .source_name }}-github-notification-provider"*/}}
+{{/*  eventSeverity: info*/}}
+{{/*  eventSources:*/}}
+{{/*    - kind: Kustomization*/}}
+{{/*      name: "{{ .name }}"*/}}
+{{/*      namespace: "{{ $.Release.Namespace }}"*/}}
+{{/*{{- end }}*/}}

--- a/helm/flux-app/values.schema.json
+++ b/helm/flux-app/values.schema.json
@@ -19,7 +19,7 @@
       "properties": {
         "size": {
           "type": "string",
-          "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+          "pattern": "^([+-]?[\\d.]+)([eEinumkKMGTP]*[-+]?\\d*)$"
         }
       },
       "additionalProperties": false

--- a/helm/flux-app/values.yaml
+++ b/helm/flux-app/values.yaml
@@ -13,7 +13,20 @@ images:
   imageReflectorController:
     image: giantswarm/fluxcd-image-reflector-controller
 
-# only GitRepository for now
+# Sources - only GitRepository for now
+#
+# Source Example
+#
+# sources:
+#   - branch: main
+#     interval: 30s
+#     kind: GitRepository
+#     name: my-git-source
+#     provider: github
+#     url: https://github.com/abc/my-git-repository
+#     credentials:
+#       username: abc
+#       password: xyz
 sources: []
 
 # Kustomizations Example


### PR DESCRIPTION
This reverts commit 9183da0318758924b25a31fb3d724bf5c722b178.

See: https://intranet.giantswarm.io/docs/dev-and-releng/app-developer-processes/handle_crds_with_helm_3/

Can be tried out with:

```yaml
---
apiVersion: v1
data:
  values: |
    sources:
      - branch: master
        interval: 30s
        kind: GitRepository
        name: podinfo
        provider: github
        url: https://github.com/stefanprodan/podinfo
        credentials:
          username: << GITHUB_USERNAME >>
          password: << GITHUB_TOKEN_WITH_REPO_SCOPE >>

    kustomizations:
      - interval: 30s
        name: podinfo
        path: ./kustomize
        prune: true
        source_name: podinfo
        postBuild:
          substitute:
            cluster_domain: "MY_DOMAIN"
            cluster_name: "CAPI_WC_NAME"
            cluster_release: "0.8.1"
            default_apps_release: "0.2.0"
            organization: "ORG_NAME"
kind: ConfigMap
metadata:
  creationTimestamp: null
  name: flux-app-userconfig-ap99a
  namespace: ap99a
---
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  name: flux-app
  namespace: ap99a
spec:
  catalog: giantswarm-test
  kubeConfig:
    inCluster: false
  name: flux-app
  namespace: ap99a
  userConfig:
    configMap:
      name: flux-app-userconfig-ap99a
      namespace: ap99a
  version: 0.13.0-9887c74e9c7990a3cf2b9d9feeb326c7b1f8e7ef


```