### PR TITLE
Upgrade Flux to v.0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bump upstream flux toolkit version to from `v0.33.0` to `v0.35.0`.
+  This upgrade comes with 1 breaking change from Flux [v0.34.0](https://github.com/fluxcd/flux2/releases/tag/v0.34.0), see: [fluxcd/flux2#3051](https://github.com/fluxcd/flux2/issues/3051).
 - Change default registry in helm chart to docker.io.
 
 ## [0.15.1] - 2022-09-07

--- a/hack/kustomization.yaml
+++ b/hack/kustomization.yaml
@@ -24,7 +24,7 @@ images:
 
 
 resources:
-- https://github.com/fluxcd/flux2/releases/download/v0.33.0/install.yaml
+- https://github.com/fluxcd/flux2/releases/download/v0.35.0/install.yaml
 - ./additional-resources/pvc-psp.yaml
 - ./additional-resources/metrics-service.yaml
 

--- a/helm/flux-app/Chart.yaml
+++ b/helm/flux-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.33.0
+appVersion: 0.35.0
 annotations:
   application.giantswarm.io/team: team-honeybadger
 description: |

--- a/helm/flux-app/crd-base/alert.yaml
+++ b/helm/flux-app/crd-base/alert.yaml
@@ -2,9 +2,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   labels:
+    app.kubernetes.io/component: notification-controller
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/name: '{{ include "name" . }}'
@@ -127,7 +128,7 @@ spec:
               properties:
                 conditions:
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     properties:
                       lastTransitionTime:
                         description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.

--- a/helm/flux-app/crd-base/bucket.yaml
+++ b/helm/flux-app/crd-base/bucket.yaml
@@ -2,9 +2,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   labels:
+    app.kubernetes.io/component: source-controller
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/name: '{{ include "name" . }}'
@@ -147,7 +148,7 @@ spec:
                 conditions:
                   description: Conditions holds the conditions for the Bucket.
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     properties:
                       lastTransitionTime:
                         description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
@@ -265,6 +266,7 @@ spec:
                   type: boolean
                 interval:
                   description: Interval at which to check the Endpoint for updates.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                   type: string
                 provider:
                   default: generic
@@ -293,6 +295,7 @@ spec:
                 timeout:
                   default: 60s
                   description: Timeout for fetch operations, defaults to 60s.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
                   type: string
               required:
                 - bucketName
@@ -339,7 +342,7 @@ spec:
                 conditions:
                   description: Conditions holds the conditions for the Bucket.
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     properties:
                       lastTransitionTime:
                         description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.

--- a/helm/flux-app/crd-base/gitrepository.yaml
+++ b/helm/flux-app/crd-base/gitrepository.yaml
@@ -2,9 +2,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   labels:
+    app.kubernetes.io/component: source-controller
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/name: '{{ include "name" . }}'
@@ -202,7 +203,7 @@ spec:
                 conditions:
                   description: Conditions holds the conditions for the GitRepository.
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     properties:
                       lastTransitionTime:
                         description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
@@ -368,6 +369,7 @@ spec:
                   type: array
                 interval:
                   description: Interval at which to check the GitRepository for updates.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                   type: string
                 recurseSubmodules:
                   description: RecurseSubmodules enables the initialization of all submodules within the GitRepository as cloned from the URL, using their default settings. This option is available only when using the 'go-git' GitImplementation.
@@ -403,6 +405,7 @@ spec:
                 timeout:
                   default: 60s
                   description: Timeout for Git operations like cloning, defaults to 60s.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
                   type: string
                 url:
                   description: URL specifies the Git repository URL, it can be an HTTP/S or SSH address.
@@ -472,7 +475,7 @@ spec:
                 conditions:
                   description: Conditions holds the conditions for the GitRepository.
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     properties:
                       lastTransitionTime:
                         description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
@@ -514,7 +517,7 @@ spec:
                     type: object
                   type: array
                 contentConfigChecksum:
-                  description: 'ContentConfigChecksum is a checksum of all the configurations related to the content of the source artifact:  - .spec.ignore  - .spec.recurseSubmodules  - .spec.included and the checksum of the included artifacts observed in .status.observedGeneration version of the object. This can be used to determine if the content of the included repository has changed. It has the format of `<algo>:<checksum>`, for example: `sha256:<checksum>`.'
+                  description: 'ContentConfigChecksum is a checksum of all the configurations related to the content of the source artifact: - .spec.ignore - .spec.recurseSubmodules - .spec.included and the checksum of the included artifacts observed in .status.observedGeneration version of the object. This can be used to determine if the content of the included repository has changed. It has the format of `<algo>:<checksum>`, for example: `sha256:<checksum>`.'
                   type: string
                 includedArtifacts:
                   description: IncludedArtifacts contains a list of the last successfully included Artifacts as instructed by GitRepositorySpec.Include.

--- a/helm/flux-app/crd-base/helmchart.yaml
+++ b/helm/flux-app/crd-base/helmchart.yaml
@@ -2,9 +2,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   labels:
+    app.kubernetes.io/component: source-controller
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/name: '{{ include "name" . }}'
@@ -164,7 +165,7 @@ spec:
                 conditions:
                   description: Conditions holds the conditions for the HelmChart.
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     properties:
                       lastTransitionTime:
                         description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
@@ -282,6 +283,7 @@ spec:
                   type: string
                 interval:
                   description: Interval is the interval at which to check the Source for updates.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                   type: string
                 reconcileStrategy:
                   default: ChartVersion
@@ -370,7 +372,7 @@ spec:
                 conditions:
                   description: Conditions holds the conditions for the HelmChart.
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     properties:
                       lastTransitionTime:
                         description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.

--- a/helm/flux-app/crd-base/helmrelease.yaml
+++ b/helm/flux-app/crd-base/helmrelease.yaml
@@ -2,9 +2,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   labels:
+    app.kubernetes.io/component: helm-controller
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/name: '{{ include "name" . }}'
@@ -61,6 +62,7 @@ spec:
                           type: string
                         interval:
                           description: Interval at which to check the v1beta2.Source for updates. Defaults to 'HelmReleaseSpec.Interval'.
+                          pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                           type: string
                         reconcileStrategy:
                           default: ChartVersion
@@ -175,10 +177,12 @@ spec:
                       type: boolean
                     timeout:
                       description: Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) during the performance of a Helm install action. Defaults to 'HelmReleaseSpec.Timeout'.
+                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
                       type: string
                   type: object
                 interval:
                   description: Interval at which to reconcile the Helm release.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                   type: string
                 kubeConfig:
                   description: KubeConfig for reconciling the HelmRelease on a remote cluster. When used in combination with HelmReleaseSpec.ServiceAccountName, forces the controller to act on behalf of that Service Account at the target cluster. If the --default-service-account flag is set, its value will be used as a controller level fallback for when HelmReleaseSpec.ServiceAccountName is empty.
@@ -363,6 +367,7 @@ spec:
                       type: boolean
                     timeout:
                       description: Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) during the performance of a Helm rollback action. Defaults to 'HelmReleaseSpec.Timeout'.
+                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
                       type: string
                   type: object
                 serviceAccountName:
@@ -392,10 +397,12 @@ spec:
                       type: boolean
                     timeout:
                       description: Timeout is the time to wait for any individual Kubernetes operation during the performance of a Helm test action. Defaults to 'HelmReleaseSpec.Timeout'.
+                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
                       type: string
                   type: object
                 timeout:
                   description: Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) during the performance of a Helm action. Defaults to '5m0s'.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
                   type: string
                 uninstall:
                   description: Uninstall holds the configuration for Helm uninstall actions for this HelmRelease.
@@ -411,6 +418,7 @@ spec:
                       type: boolean
                     timeout:
                       description: Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) during the performance of a Helm uninstall action. Defaults to 'HelmReleaseSpec.Timeout'.
+                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
                       type: string
                   type: object
                 upgrade:
@@ -465,6 +473,7 @@ spec:
                       type: object
                     timeout:
                       description: Timeout is the time to wait for any individual Kubernetes operation (like Jobs for hooks) during the performance of a Helm upgrade action. Defaults to 'HelmReleaseSpec.Timeout'.
+                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
                       type: string
                   type: object
                 values:
@@ -516,7 +525,7 @@ spec:
                 conditions:
                   description: Conditions holds the conditions for the HelmRelease.
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     properties:
                       lastTransitionTime:
                         description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.

--- a/helm/flux-app/crd-base/helmrepository.yaml
+++ b/helm/flux-app/crd-base/helmrepository.yaml
@@ -2,9 +2,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   labels:
+    app.kubernetes.io/component: source-controller
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/name: '{{ include "name" . }}'
@@ -131,7 +132,7 @@ spec:
                 conditions:
                   description: Conditions holds the conditions for the HelmRepository.
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     properties:
                       lastTransitionTime:
                         description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
@@ -237,6 +238,7 @@ spec:
                   type: object
                 interval:
                   description: Interval at which to check the URL for updates.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                   type: string
                 passCredentials:
                   description: PassCredentials allows the credentials from the SecretRef to be passed on to a host that does not match the host as defined in URL. This may be required if the host of the advertised chart URLs in the index differ from the defined URL. Enabling this should be done with caution, as it can potentially result in credentials getting stolen in a MITM-attack.
@@ -265,6 +267,7 @@ spec:
                 timeout:
                   default: 60s
                   description: Timeout is used for the index fetch operation for an HTTPS helm repository, and for remote OCI Repository operations like pulling for an OCI helm repository. Its default value is 60s.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
                   type: string
                 type:
                   description: Type of the HelmRepository. When this field is set to  "oci", the URL field value must be prefixed with "oci://".
@@ -319,7 +322,7 @@ spec:
                 conditions:
                   description: Conditions holds the conditions for the HelmRepository.
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     properties:
                       lastTransitionTime:
                         description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.

--- a/helm/flux-app/crd-base/imagepolicy.yaml
+++ b/helm/flux-app/crd-base/imagepolicy.yaml
@@ -2,9 +2,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   labels:
+    app.kubernetes.io/component: image-reflector-controller
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/name: '{{ include "name" . }}'
@@ -105,7 +106,7 @@ spec:
               properties:
                 conditions:
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     properties:
                       lastTransitionTime:
                         description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
@@ -241,7 +242,7 @@ spec:
               properties:
                 conditions:
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     properties:
                       lastTransitionTime:
                         description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
@@ -382,7 +383,7 @@ spec:
               properties:
                 conditions:
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     properties:
                       lastTransitionTime:
                         description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.

--- a/helm/flux-app/crd-base/imagerepository.yaml
+++ b/helm/flux-app/crd-base/imagerepository.yaml
@@ -2,9 +2,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   labels:
+    app.kubernetes.io/component: image-reflector-controller
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/name: '{{ include "name" . }}'
@@ -46,7 +47,7 @@ spec:
               description: ImageRepositorySpec defines the parameters for scanning an image repository, e.g., `fluxcd/flux`.
               properties:
                 certSecretRef:
-                  description: "CertSecretRef can be given the name of a secret containing either or both of \n  - a PEM-encoded client certificate (`certFile`) and private  key (`keyFile`);  - a PEM-encoded CA certificate (`caFile`) \n  and whichever are supplied, will be used for connecting to the  registry. The client cert and key are useful if you are  authenticating with a certificate; the CA cert is useful if  you are using a self-signed server certificate."
+                  description: "CertSecretRef can be given the name of a secret containing either or both of \n - a PEM-encoded client certificate (`certFile`) and private key (`keyFile`); - a PEM-encoded CA certificate (`caFile`) \n and whichever are supplied, will be used for connecting to the registry. The client cert and key are useful if you are authenticating with a certificate; the CA cert is useful if you are using a self-signed server certificate."
                   properties:
                     name:
                       description: Name of the referent.
@@ -84,7 +85,7 @@ spec:
                   type: string
                 conditions:
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     properties:
                       lastTransitionTime:
                         description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
@@ -173,7 +174,7 @@ spec:
               description: ImageRepositorySpec defines the parameters for scanning an image repository, e.g., `fluxcd/flux`.
               properties:
                 certSecretRef:
-                  description: "CertSecretRef can be given the name of a secret containing either or both of \n  - a PEM-encoded client certificate (`certFile`) and private  key (`keyFile`);  - a PEM-encoded CA certificate (`caFile`) \n  and whichever are supplied, will be used for connecting to the  registry. The client cert and key are useful if you are  authenticating with a certificate; the CA cert is useful if  you are using a self-signed server certificate."
+                  description: "CertSecretRef can be given the name of a secret containing either or both of \n - a PEM-encoded client certificate (`certFile`) and private key (`keyFile`); - a PEM-encoded CA certificate (`caFile`) \n and whichever are supplied, will be used for connecting to the registry. The client cert and key are useful if you are authenticating with a certificate; the CA cert is useful if you are using a self-signed server certificate."
                   properties:
                     name:
                       description: Name of the referent.
@@ -211,7 +212,7 @@ spec:
                   type: string
                 conditions:
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     properties:
                       lastTransitionTime:
                         description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
@@ -318,7 +319,7 @@ spec:
                     - namespaceSelectors
                   type: object
                 certSecretRef:
-                  description: "CertSecretRef can be given the name of a secret containing either or both of \n  - a PEM-encoded client certificate (`certFile`) and private  key (`keyFile`);  - a PEM-encoded CA certificate (`caFile`) \n  and whichever are supplied, will be used for connecting to the  registry. The client cert and key are useful if you are  authenticating with a certificate; the CA cert is useful if  you are using a self-signed server certificate."
+                  description: "CertSecretRef can be given the name of a secret containing either or both of \n - a PEM-encoded client certificate (`certFile`) and private key (`keyFile`); - a PEM-encoded CA certificate (`caFile`) \n and whichever are supplied, will be used for connecting to the registry. The client cert and key are useful if you are authenticating with a certificate; the CA cert is useful if you are using a self-signed server certificate."
                   properties:
                     name:
                       description: Name of the referent.
@@ -336,6 +337,7 @@ spec:
                   type: string
                 interval:
                   description: Interval is the length of time to wait between scans of the image repository.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                   type: string
                 secretRef:
                   description: SecretRef can be given the name of a secret containing credentials to use for the image registry. The secret should be created with `kubectl create secret docker-registry`, or the equivalent.
@@ -348,12 +350,14 @@ spec:
                   type: object
                 serviceAccountName:
                   description: ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate the image pull if the service account has attached pull secrets.
+                  maxLength: 253
                   type: string
                 suspend:
                   description: This flag tells the controller to suspend subsequent image scans. It does not apply to already started scans. Defaults to false.
                   type: boolean
                 timeout:
                   description: Timeout for image scanning. Defaults to 'Interval' duration.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
                   type: string
               type: object
             status:
@@ -366,7 +370,7 @@ spec:
                   type: string
                 conditions:
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     properties:
                       lastTransitionTime:
                         description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.

--- a/helm/flux-app/crd-base/imageupdateautomation.yaml
+++ b/helm/flux-app/crd-base/imageupdateautomation.yaml
@@ -2,9 +2,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   labels:
+    app.kubernetes.io/component: image-automation-controller
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/name: '{{ include "name" . }}'
@@ -132,7 +133,7 @@ spec:
               properties:
                 conditions:
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     properties:
                       lastTransitionTime:
                         description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
@@ -338,7 +339,7 @@ spec:
               properties:
                 conditions:
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     properties:
                       lastTransitionTime:
                         description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
@@ -495,6 +496,7 @@ spec:
                   type: object
                 interval:
                   description: Interval gives an lower bound for how often the automation run should be attempted.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                   type: string
                 sourceRef:
                   description: SourceRef refers to the resource giving access details to a git repository.
@@ -549,7 +551,7 @@ spec:
               properties:
                 conditions:
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     properties:
                       lastTransitionTime:
                         description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.

--- a/helm/flux-app/crd-base/kustomization.yaml
+++ b/helm/flux-app/crd-base/kustomization.yaml
@@ -2,9 +2,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   labels:
+    app.kubernetes.io/component: kustomize-controller
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/name: '{{ include "name" . }}'
@@ -346,7 +347,7 @@ spec:
               properties:
                 conditions:
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     properties:
                       lastTransitionTime:
                         description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
@@ -543,6 +544,7 @@ spec:
                   type: array
                 interval:
                   description: The interval at which to reconcile the Kustomization.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                   type: string
                 kubeConfig:
                   description: The KubeConfig for reconciling the Kustomization on a remote cluster. When used in combination with KustomizationSpec.ServiceAccountName, forces the controller to act on behalf of that Service Account at the target cluster. If the --default-service-account flag is set, its value will be used as a controller level fallback for when KustomizationSpec.ServiceAccountName is empty.
@@ -706,6 +708,7 @@ spec:
                   type: boolean
                 retryInterval:
                   description: The interval at which to retry a previously failed reconciliation. When not specified, the controller uses the KustomizationSpec.Interval value to retry failures.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                   type: string
                 serviceAccountName:
                   description: The name of the Kubernetes service account to impersonate when reconciling this Kustomization.
@@ -743,6 +746,7 @@ spec:
                   type: string
                 timeout:
                   description: Timeout for validation, apply and health checking operations. Defaults to 'Interval' duration.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
                   type: string
                 validation:
                   description: 'Deprecated: Not used in v1beta2.'
@@ -766,7 +770,7 @@ spec:
               properties:
                 conditions:
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     properties:
                       lastTransitionTime:
                         description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.

--- a/helm/flux-app/crd-base/ocirepository.yaml
+++ b/helm/flux-app/crd-base/ocirepository.yaml
@@ -2,9 +2,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   labels:
+    app.kubernetes.io/component: source-controller
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/name: '{{ include "name" . }}'
@@ -54,7 +55,7 @@ spec:
               description: OCIRepositorySpec defines the desired state of OCIRepository
               properties:
                 certSecretRef:
-                  description: "CertSecretRef can be given the name of a secret containing either or both of \n  - a PEM-encoded client certificate (`certFile`) and private  key (`keyFile`);  - a PEM-encoded CA certificate (`caFile`) \n  and whichever are supplied, will be used for connecting to the  registry. The client cert and key are useful if you are  authenticating with a certificate; the CA cert is useful if  you are using a self-signed server certificate."
+                  description: "CertSecretRef can be given the name of a secret containing either or both of \n - a PEM-encoded client certificate (`certFile`) and private key (`keyFile`); - a PEM-encoded CA certificate (`caFile`) \n and whichever are supplied, will be used for connecting to the registry. The client cert and key are useful if you are authenticating with a certificate; the CA cert is useful if you are using a self-signed server certificate."
                   properties:
                     name:
                       description: Name of the referent.
@@ -65,14 +66,24 @@ spec:
                 ignore:
                   description: Ignore overrides the set of excluded patterns in the .sourceignore format (which is the same as .gitignore). If not provided, a default will be used, consult the documentation for your version to find out what those are.
                   type: string
+                insecure:
+                  description: Insecure allows connecting to a non-TLS HTTP container registry.
+                  type: boolean
                 interval:
                   description: The interval at which to check for image updates.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                   type: string
                 layerSelector:
                   description: LayerSelector specifies which layer should be extracted from the OCI artifact. When not specified, the first layer found in the artifact is selected.
                   properties:
                     mediaType:
                       description: MediaType specifies the OCI media type of the layer which should be extracted from the OCI Artifact. The first layer matching this type is selected.
+                      type: string
+                    operation:
+                      description: Operation specifies how the selected layer should be processed. By default, the layer compressed content is extracted to storage. When the operation is set to 'copy', the layer compressed content is persisted to storage as it is.
+                      enum:
+                        - extract
+                        - copy
                       type: string
                   type: object
                 provider:
@@ -115,11 +126,33 @@ spec:
                 timeout:
                   default: 60s
                   description: The timeout for remote OCI Repository operations like pulling, defaults to 60s.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
                   type: string
                 url:
                   description: URL is a reference to an OCI artifact repository hosted on a remote container registry.
                   pattern: ^oci://.*$
                   type: string
+                verify:
+                  description: Verify contains the secret name containing the trusted public keys used to verify the signature and specifies which provider to use to check whether OCI image is authentic.
+                  properties:
+                    provider:
+                      default: cosign
+                      description: Provider specifies the technology used to sign the OCI Artifact.
+                      enum:
+                        - cosign
+                      type: string
+                    secretRef:
+                      description: SecretRef specifies the Kubernetes Secret containing the trusted public keys.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                  required:
+                    - provider
+                  type: object
               required:
                 - interval
                 - url
@@ -164,7 +197,7 @@ spec:
                 conditions:
                   description: Conditions holds the conditions for the OCIRepository.
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     properties:
                       lastTransitionTime:
                         description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
@@ -205,6 +238,9 @@ spec:
                       - type
                     type: object
                   type: array
+                contentConfigChecksum:
+                  description: 'ContentConfigChecksum is a checksum of all the configurations related to the content of the source artifact: - .spec.ignore - .spec.layerSelector observed in .status.observedGeneration version of the object. This can be used to determine if the content configuration has changed and the artifact needs to be rebuilt. It has the format of `<algo>:<checksum>`, for example: `sha256:<checksum>`.'
+                  type: string
                 lastHandledReconcileAt:
                   description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change of the annotation value can be detected.
                   type: string

--- a/helm/flux-app/crd-base/provider.yaml
+++ b/helm/flux-app/crd-base/provider.yaml
@@ -2,9 +2,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   labels:
+    app.kubernetes.io/component: notification-controller
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/name: '{{ include "name" . }}'
@@ -80,6 +81,10 @@ spec:
                 suspend:
                   description: This flag tells the controller to suspend subsequent events handling. Defaults to false.
                   type: boolean
+                timeout:
+                  description: Timeout for sending alerts to the provider.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                  type: string
                 type:
                   description: Type of provider
                   enum:
@@ -117,7 +122,7 @@ spec:
               properties:
                 conditions:
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     properties:
                       lastTransitionTime:
                         description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.

--- a/helm/flux-app/crd-base/receiver.yaml
+++ b/helm/flux-app/crd-base/receiver.yaml
@@ -2,9 +2,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   labels:
+    app.kubernetes.io/component: notification-controller
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/name: '{{ include "name" . }}'
@@ -132,7 +133,7 @@ spec:
               properties:
                 conditions:
                   items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                     properties:
                       lastTransitionTime:
                         description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.

--- a/helm/flux-app/templates/install.yaml
+++ b/helm/flux-app/templates/install.yaml
@@ -2,97 +2,103 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/component: helm-controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     giantswarm.io/service_type: managed
-    helm.sh/chart: '{{ include "chart" . }}'
+    helm.sh/chart: {{ include "chart" . }}
   name: helm-controller
-  namespace: '{{ .Release.Namespace }}'
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/component: image-automation-controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     giantswarm.io/service_type: managed
-    helm.sh/chart: '{{ include "chart" . }}'
+    helm.sh/chart: {{ include "chart" . }}
   name: image-automation-controller
-  namespace: '{{ .Release.Namespace }}'
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/component: image-reflector-controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     giantswarm.io/service_type: managed
-    helm.sh/chart: '{{ include "chart" . }}'
+    helm.sh/chart: {{ include "chart" . }}
   name: image-reflector-controller
-  namespace: '{{ .Release.Namespace }}'
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/component: kustomize-controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     giantswarm.io/service_type: managed
-    helm.sh/chart: '{{ include "chart" . }}'
+    helm.sh/chart: {{ include "chart" . }}
   name: kustomize-controller
-  namespace: '{{ .Release.Namespace }}'
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/component: notification-controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     giantswarm.io/service_type: managed
-    helm.sh/chart: '{{ include "chart" . }}'
+    helm.sh/chart: {{ include "chart" . }}
   name: notification-controller
-  namespace: '{{ .Release.Namespace }}'
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/component: source-controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     giantswarm.io/service_type: managed
-    helm.sh/chart: '{{ include "chart" . }}'
+    helm.sh/chart: {{ include "chart" . }}
   name: source-controller
-  namespace: '{{ .Release.Namespace }}'
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   labels:
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
-    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     giantswarm.io/service_type: managed
-    helm.sh/chart: '{{ include "chart" . }}'
-  name: '{{ printf "%s-pvc-psp" (include "name" .) }}'
+    helm.sh/chart: {{ include "chart" . }}
+  name: {{ printf "%s-pvc-psp" (include "name" .) }}
 spec:
   allowPrivilegeEscalation: false
   fsGroup:
@@ -118,13 +124,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     giantswarm.io/service_type: managed
-    helm.sh/chart: '{{ include "chart" . }}'
+    helm.sh/chart: {{ include "chart" . }}
   name: crd-controller
 rules:
   - apiGroups:
@@ -210,7 +216,7 @@ rules:
   - apiGroups:
       - policy
     resourceNames:
-      - '{{ printf "%s-pvc-psp" (include "name" .) }}'
+      - {{ printf "%s-pvc-psp" (include "name" .) }}
     resources:
       - podsecuritypolicies
     verbs:
@@ -220,13 +226,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     giantswarm.io/service_type: managed
-    helm.sh/chart: '{{ include "chart" . }}'
+    helm.sh/chart: {{ include "chart" . }}
   name: cluster-reconciler
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -235,22 +241,22 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: kustomize-controller
-    namespace: '{{ .Release.Namespace }}'
+    namespace: {{ .Release.Namespace }}
   - kind: ServiceAccount
     name: helm-controller
-    namespace: '{{ .Release.Namespace }}'
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     giantswarm.io/service_type: managed
-    helm.sh/chart: '{{ include "chart" . }}'
+    helm.sh/chart: {{ include "chart" . }}
   name: crd-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -259,37 +265,38 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: kustomize-controller
-    namespace: '{{ .Release.Namespace }}'
+    namespace: {{ .Release.Namespace }}
   - kind: ServiceAccount
     name: helm-controller
-    namespace: '{{ .Release.Namespace }}'
+    namespace: {{ .Release.Namespace }}
   - kind: ServiceAccount
     name: source-controller
-    namespace: '{{ .Release.Namespace }}'
+    namespace: {{ .Release.Namespace }}
   - kind: ServiceAccount
     name: notification-controller
-    namespace: '{{ .Release.Namespace }}'
+    namespace: {{ .Release.Namespace }}
   - kind: ServiceAccount
     name: image-reflector-controller
-    namespace: '{{ .Release.Namespace }}'
+    namespace: {{ .Release.Namespace }}
   - kind: ServiceAccount
     name: image-automation-controller
-    namespace: '{{ .Release.Namespace }}'
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/component: notification-controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     control-plane: controller
     giantswarm.io/service_type: managed
-    helm.sh/chart: '{{ include "chart" . }}'
+    helm.sh/chart: {{ include "chart" . }}
   name: notification-controller
-  namespace: '{{ .Release.Namespace }}'
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
     - name: http
@@ -298,25 +305,26 @@ spec:
       targetPort: http
   selector:
     app: notification-controller
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
   type: ClusterIP
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/component: source-controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     control-plane: controller
     giantswarm.io/service_type: managed
-    helm.sh/chart: '{{ include "chart" . }}'
+    helm.sh/chart: {{ include "chart" . }}
   name: source-controller
-  namespace: '{{ .Release.Namespace }}'
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
     - name: http
@@ -325,25 +333,26 @@ spec:
       targetPort: http
   selector:
     app: source-controller
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
   type: ClusterIP
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/component: notification-controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     control-plane: controller
     giantswarm.io/service_type: managed
-    helm.sh/chart: '{{ include "chart" . }}'
+    helm.sh/chart: {{ include "chart" . }}
   name: webhook-receiver
-  namespace: '{{ .Release.Namespace }}'
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
     - name: http
@@ -352,9 +361,9 @@ spec:
       targetPort: http-webhook
   selector:
     app: notification-controller
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
   type: ClusterIP
 ---
 apiVersion: v1
@@ -364,49 +373,50 @@ metadata:
     giantswarm.io/monitoring-path: /metrics
     giantswarm.io/monitoring-port: "8080"
   labels:
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
-    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     giantswarm.io/monitoring: "true"
     giantswarm.io/service_type: managed
-    helm.sh/chart: '{{ include "chart" . }}'
-  name: '{{ .Release.Name  }}-monitoring'
-  namespace: '{{ .Release.Namespace }}'
+    helm.sh/chart: {{ include "chart" . }}
+  name: {{ .Release.Name  }}-monitoring'
+  namespace: {{ .Release.Namespace }}
 spec:
   clusterIP: None
   ports:
     - port: 8080
       protocol: TCP
-      targetPort: '{{ .Values.upstreamMetricsPort }}'
+      targetPort: {{ .Values.upstreamMetricsPort }}
   selector:
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     app: helm-controller
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/component: helm-controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     control-plane: controller
     giantswarm.io/service_type: managed
-    helm.sh/chart: '{{ include "chart" . }}'
+    helm.sh/chart: {{ include "chart" . }}
   name: helm-controller
-  namespace: '{{ .Release.Namespace }}'
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: helm-controller
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-      app.kubernetes.io/name: '{{ include "name" . }}'
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      app.kubernetes.io/name: {{ include "name" . }}
   template:
     metadata:
       annotations:
@@ -414,12 +424,12 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app: helm-controller
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-        app.kubernetes.io/name: '{{ include "name" . }}'
-        app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ include "name" . }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
         giantswarm.io/service_type: managed
-        helm.sh/chart: '{{ include "chart" . }}'
+        helm.sh/chart: {{ include "chart" . }}
     spec:
       containers:
         - args:
@@ -433,7 +443,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: '{{ .Values.images.registry }}/{{ .Values.images.helmController.image }}:v0.23.1'
+          image: '{{ .Values.images.registry }}/{{ .Values.images.helmController.image }}:v0.25.0'
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -453,11 +463,11 @@ spec:
               port: healthz
           resources:
             limits:
-              cpu: '{{ .Values.resources.helmController.limits.cpu }}'
-              memory: '{{ .Values.resources.helmController.limits.memory }}'
+              cpu: {{ .Values.resources.helmController.limits.cpu }}
+              memory: {{ .Values.resources.helmController.limits.memory }}
             requests:
-              cpu: '{{ .Values.resources.helmController.requests.cpu }}'
-              memory: '{{ .Values.resources.helmController.requests.memory }}'
+              cpu: {{ .Values.resources.helmController.requests.cpu }}
+              memory: {{ .Values.resources.helmController.requests.memory }}
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -478,24 +488,25 @@ kind: Deployment
 metadata:
   labels:
     app: image-automation-controlller
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/component: image-automation-controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     control-plane: controller
     giantswarm.io/service_type: managed
-    helm.sh/chart: '{{ include "chart" . }}'
+    helm.sh/chart: {{ include "chart" . }}
   name: image-automation-controller
-  namespace: '{{ .Release.Namespace }}'
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: image-automation-controller
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-      app.kubernetes.io/name: '{{ include "name" . }}'
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      app.kubernetes.io/name: {{ include "name" . }}
   template:
     metadata:
       annotations:
@@ -503,12 +514,12 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app: image-automation-controller
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-        app.kubernetes.io/name: '{{ include "name" . }}'
-        app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ include "name" . }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
         giantswarm.io/service_type: managed
-        helm.sh/chart: '{{ include "chart" . }}'
+        helm.sh/chart: {{ include "chart" . }}
     spec:
       containers:
         - args:
@@ -522,7 +533,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: '{{ .Values.images.registry }}/{{ .Values.images.imageAutomationController.image }}:v0.24.2'
+          image: '{{ .Values.images.registry }}/{{ .Values.images.imageAutomationController.image }}:v0.26.0'
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -542,11 +553,11 @@ spec:
               port: healthz
           resources:
             limits:
-              cpu: '{{ .Values.resources.imageAutomationController.limits.cpu }}'
-              memory: '{{ .Values.resources.imageAutomationController.limits.memory }}'
+              cpu: {{ .Values.resources.imageAutomationController.limits.cpu }}
+              memory: {{ .Values.resources.imageAutomationController.limits.memory }}
             requests:
-              cpu: '{{ .Values.resources.imageAutomationController.requests.cpu }}'
-              memory: '{{ .Values.resources.imageAutomationController.requests.memory }}'
+              cpu: {{ .Values.resources.imageAutomationController.requests.cpu }}
+              memory: {{ .Values.resources.imageAutomationController.requests.memory }}
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -567,24 +578,25 @@ kind: Deployment
 metadata:
   labels:
     app: image-reflector-controller
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/component: image-reflector-controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     control-plane: controller
     giantswarm.io/service_type: managed
-    helm.sh/chart: '{{ include "chart" . }}'
+    helm.sh/chart: {{ include "chart" . }}
   name: image-reflector-controller
-  namespace: '{{ .Release.Namespace }}'
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: image-reflector-controller
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-      app.kubernetes.io/name: '{{ include "name" . }}'
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      app.kubernetes.io/name: {{ include "name" . }}
   template:
     metadata:
       annotations:
@@ -592,12 +604,12 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app: image-reflector-controller
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-        app.kubernetes.io/name: '{{ include "name" . }}'
-        app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ include "name" . }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
         giantswarm.io/service_type: managed
-        helm.sh/chart: '{{ include "chart" . }}'
+        helm.sh/chart: {{ include "chart" . }}
     spec:
       containers:
         - args:
@@ -611,7 +623,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: '{{ .Values.images.registry }}/{{ .Values.images.imageReflectorController.image }}:v0.20.1'
+          image: '{{ .Values.images.registry }}/{{ .Values.images.imageReflectorController.image }}:v0.22.0'
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -631,11 +643,11 @@ spec:
               port: healthz
           resources:
             limits:
-              cpu: '{{ .Values.resources.imageReflectorController.limits.cpu }}'
-              memory: '{{ .Values.resources.imageReflectorController.limits.memory }}'
+              cpu: {{ .Values.resources.imageReflectorController.limits.cpu }}
+              memory: {{ .Values.resources.imageReflectorController.limits.memory }}
             requests:
-              cpu: '{{ .Values.resources.imageReflectorController.requests.cpu }}'
-              memory: '{{ .Values.resources.imageReflectorController.requests.memory }}'
+              cpu: {{ .Values.resources.imageReflectorController.requests.cpu }}
+              memory: {{ .Values.resources.imageReflectorController.requests.memory }}
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -660,24 +672,25 @@ kind: Deployment
 metadata:
   labels:
     app: kustomize-controller
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/component: kustomize-controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     control-plane: controller
     giantswarm.io/service_type: managed
-    helm.sh/chart: '{{ include "chart" . }}'
+    helm.sh/chart: {{ include "chart" . }}
   name: kustomize-controller
-  namespace: '{{ .Release.Namespace }}'
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: kustomize-controller
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-      app.kubernetes.io/name: '{{ include "name" . }}'
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      app.kubernetes.io/name: {{ include "name" . }}
   template:
     metadata:
       annotations:
@@ -685,12 +698,12 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app: kustomize-controller
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-        app.kubernetes.io/name: '{{ include "name" . }}'
-        app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ include "name" . }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
         giantswarm.io/service_type: managed
-        helm.sh/chart: '{{ include "chart" . }}'
+        helm.sh/chart: {{ include "chart" . }}
     spec:
       containers:
         - args:
@@ -704,7 +717,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: '{{ .Values.images.registry }}/{{ .Values.images.kustomizeController.image }}:v0.27.1'
+          image: '{{ .Values.images.registry }}/{{ .Values.images.kustomizeController.image }}:v0.29.0'
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -724,11 +737,11 @@ spec:
               port: healthz
           resources:
             limits:
-              cpu: '{{ .Values.resources.kustomizeController.limits.cpu }}'
-              memory: '{{ .Values.resources.kustomizeController.limits.memory }}'
+              cpu: {{ .Values.resources.kustomizeController.limits.cpu }}
+              memory: {{ .Values.resources.kustomizeController.limits.memory }}
             requests:
-              cpu: '{{ .Values.resources.kustomizeController.requests.cpu }}'
-              memory: '{{ .Values.resources.kustomizeController.requests.memory }}'
+              cpu: {{ .Values.resources.kustomizeController.requests.cpu }}
+              memory: {{ .Values.resources.kustomizeController.requests.memory }}
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -749,24 +762,25 @@ kind: Deployment
 metadata:
   labels:
     app: notification-controller
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/component: notification-controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     control-plane: controller
     giantswarm.io/service_type: managed
-    helm.sh/chart: '{{ include "chart" . }}'
+    helm.sh/chart: {{ include "chart" . }}
   name: notification-controller
-  namespace: '{{ .Release.Namespace }}'
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: notification-controller
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-      app.kubernetes.io/name: '{{ include "name" . }}'
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      app.kubernetes.io/name: {{ include "name" . }}
   template:
     metadata:
       annotations:
@@ -774,12 +788,12 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app: notification-controller
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-        app.kubernetes.io/name: '{{ include "name" . }}'
-        app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ include "name" . }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
         giantswarm.io/service_type: managed
-        helm.sh/chart: '{{ include "chart" . }}'
+        helm.sh/chart: {{ include "chart" . }}
     spec:
       containers:
         - args:
@@ -792,7 +806,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: '{{ .Values.images.registry }}/{{ .Values.images.notificationController.image }}:v0.25.2'
+          image: '{{ .Values.images.registry }}/{{ .Values.images.notificationController.image }}:v0.27.0'
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -818,11 +832,11 @@ spec:
               port: healthz
           resources:
             limits:
-              cpu: '{{ .Values.resources.notificationController.limits.cpu }}'
-              memory: '{{ .Values.resources.notificationController.limits.memory }}'
+              cpu: {{ .Values.resources.notificationController.limits.cpu }}
+              memory: {{ .Values.resources.notificationController.limits.memory }}
             requests:
-              cpu: '{{ .Values.resources.notificationController.requests.cpu }}'
-              memory: '{{ .Values.resources.notificationController.requests.memory }}'
+              cpu: {{ .Values.resources.notificationController.requests.cpu }}
+              memory: {{ .Values.resources.notificationController.requests.memory }}
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -843,24 +857,25 @@ kind: Deployment
 metadata:
   labels:
     app: source-controller
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/component: source-controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     control-plane: controller
     giantswarm.io/service_type: managed
-    helm.sh/chart: '{{ include "chart" . }}'
+    helm.sh/chart: {{ include "chart" . }}
   name: source-controller
-  namespace: '{{ .Release.Namespace }}'
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: source-controller
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-      app.kubernetes.io/name: '{{ include "name" . }}'
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      app.kubernetes.io/name: {{ include "name" . }}
   strategy:
     type: Recreate
   template:
@@ -870,12 +885,12 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app: source-controller
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-        app.kubernetes.io/name: '{{ include "name" . }}'
-        app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ include "name" . }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
         giantswarm.io/service_type: managed
-        helm.sh/chart: '{{ include "chart" . }}'
+        helm.sh/chart: {{ include "chart" . }}
     spec:
       containers:
         - args:
@@ -891,7 +906,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: '{{ .Values.images.registry }}/{{ .Values.images.sourceController.image }}:v0.28.0'
+            - name: TUF_ROOT
+              value: /tmp/.sigstore
+          image: '{{ .Values.images.registry }}/{{ .Values.images.sourceController.image }}:v0.30.0'
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -914,11 +931,11 @@ spec:
               port: http
           resources:
             limits:
-              cpu: '{{ .Values.resources.sourceController.limits.cpu }}'
-              memory: '{{ .Values.resources.sourceController.limits.memory }}'
+              cpu: {{ .Values.resources.sourceController.limits.cpu }}
+              memory: {{ .Values.resources.sourceController.limits.memory }}
             requests:
-              cpu: '{{ .Values.resources.sourceController.requests.cpu }}'
-              memory: '{{ .Values.resources.sourceController.requests.memory }}'
+              cpu: {{ .Values.resources.sourceController.requests.cpu }}
+              memory: {{ .Values.resources.sourceController.requests.memory }}
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -942,15 +959,15 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   labels:
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     giantswarm.io/service_type: managed
-    helm.sh/chart: '{{ include "chart" . }}'
+    helm.sh/chart: {{ include "chart" . }}
   name: allow-egress
-  namespace: '{{ .Release.Namespace }}'
+  namespace: {{ .Release.Namespace }}
 spec:
   egress:
     - {}
@@ -966,15 +983,15 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   labels:
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     giantswarm.io/service_type: managed
-    helm.sh/chart: '{{ include "chart" . }}'
+    helm.sh/chart: {{ include "chart" . }}
   name: allow-scraping
-  namespace: '{{ .Release.Namespace }}'
+  namespace: {{ .Release.Namespace }}
 spec:
   egress:
     - {}
@@ -984,9 +1001,9 @@ spec:
           protocol: TCP
   podSelector:
     matchLabels:
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-      app.kubernetes.io/name: '{{ include "name" . }}'
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      app.kubernetes.io/name: {{ include "name" . }}
   policyTypes:
     - Egress
     - Ingress
@@ -995,15 +1012,15 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   labels:
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: '{{ include "name" . }}'
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
     app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     giantswarm.io/service_type: managed
-    helm.sh/chart: '{{ include "chart" . }}'
+    helm.sh/chart: {{ include "chart" . }}
   name: allow-webhooks
-  namespace: '{{ .Release.Namespace }}'
+  namespace: {{ .Release.Namespace }}
 spec:
   ingress:
     - from:
@@ -1011,8 +1028,8 @@ spec:
   podSelector:
     matchLabels:
       app: notification-controller
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-      app.kubernetes.io/name: '{{ include "name" . }}'
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      app.kubernetes.io/name: {{ include "name" . }}
   policyTypes:
     - Ingress

--- a/helm/flux-app/templates/install.yaml
+++ b/helm/flux-app/templates/install.yaml
@@ -380,7 +380,7 @@ metadata:
     giantswarm.io/monitoring: "true"
     giantswarm.io/service_type: managed
     helm.sh/chart: {{ include "chart" . }}
-  name: {{ .Release.Name  }}-monitoring'
+  name: {{ .Release.Name  }}-monitoring
   namespace: {{ .Release.Namespace }}
 spec:
   clusterIP: None


### PR DESCRIPTION
There is 1 breaking change in v0.34.0: they change the log format by renaming 3 fields, see https://github.com/fluxcd/flux2/issues/3051. From what I can tell this is not an issue for us.