### PR TITLE
Add capability to set annotations on the kustomize SA

### DIFF
--- a/helm/flux-app/templates/install.yaml
+++ b/helm/flux-app/templates/install.yaml
@@ -55,6 +55,12 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     giantswarm.io/service_type: managed
     helm.sh/chart: {{ include "chart" . }}
+{{- if (.Values.kustomizeServiceAccount.annotations) }}
+  annotations:
+{{- range $k, $v := .Values.kustomizeServiceAccount.annotations }}
+    {{ $k }}: {{ $v }}
+{{- end -}}
+{{- end }}
   name: kustomize-controller
   namespace: {{ .Release.Namespace }}
 ---

--- a/helm/flux-app/values.schema.json
+++ b/helm/flux-app/values.schema.json
@@ -25,7 +25,7 @@
       "additionalProperties": false
     }
   },
-  "required": ["images", "cluster", "sources", "kustomizations", "volumes"],
+  "required": ["images", "cluster", "sources", "kustomizations", "volumes", "kustomizeServiceAccount"],
   "properties": {
     "images": {
       "type": "object",
@@ -338,6 +338,13 @@
         }
       },
       "additionalProperties": false
+    },
+    "kustomizeServiceAccount": {
+      "type": "object",
+      "required": ["annotations"],
+      "properties": {
+        "annotations": {"type": "object"}
+      }
     }
   },
   "additionalProperties": true

--- a/helm/flux-app/values.yaml
+++ b/helm/flux-app/values.yaml
@@ -128,3 +128,9 @@ volumes:
       size: 100Mi
     data:
       size: 100Mi
+
+# Annotations to add on to the kustomize controller service account
+# Allows for adding custom annotations such as those required for use of
+# KMS keys.
+kustomizeServiceAccount:
+  annotations: {}


### PR DESCRIPTION
This PR adds the capbiility of annotating the service account used by `kustomize-controller`

This originally came from a customer request for the capability of using a custom SA in place of the SA used by `kustomize-controller` however on reflection and discussions with the customer, it was determined that the only capability actually required was the additional capability of annotating the `kustomize-controller` service account to include annotations for KMS integration.

This is considered safer than using a custom SA, ensures everything is self contained and prevents the requirement for resources to be created outside of the flux-app helm deployment.