### PR TITLE
Add custom annotations and labels to kustomize-controller pod template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add capability to attach custom labels and annotations to kustomize-contoller pod template
+
 ## [0.19.0] - 2022-11-24
 
 - Add capability to annotate the kustomize-controller service account

--- a/hack/patches/kustomize-controller-deploy-patch.yaml
+++ b/hack/patches/kustomize-controller-deploy-patch.yaml
@@ -13,3 +13,9 @@
 - op: replace
   path: /spec/template/spec/containers/0/args/0
   value: --events-addr=http://notification-controller.{{ .Release.Namespace }}.svc.{{ .Values.cluster.domain }}./
+- op: replace
+  path: /spec/template/metadata/annotations
+  value: '{{ include "podTemplateAnnotations.kustomizeController" . }}'
+- op: replace
+  path: /spec/template/metadata/labels
+  value: '{{ include "podTemplateLabels.kustomizeController" . }}'

--- a/helm/flux-app/templates/_helpers.tpl
+++ b/helm/flux-app/templates/_helpers.tpl
@@ -138,3 +138,29 @@ limits:
 {{ toYaml .Values.resources.sourceController.limits | indent 2 -}}
 {{- end -}}
 {{- end -}}
+
+{{ define "podTemplateAnnotations.kustomizeController" }}
+{{- printf "prometheus.io/port: \"8080\"" | nindent 8 -}}
+{{- printf "prometheus.io/scrape: \"true\"" | nindent 8 }}
+{{- if (.Values.kustomizeController.podTemplate.annotations) -}}
+{{- range $k, $v := .Values.kustomizeController.podTemplate.annotations }}
+{{- $k | nindent 8 }}: {{ $v }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "podTemplateLabels.kustomizeController" -}}
+{{- printf "app: kustomize-controller" | nindent 8 -}}
+{{- printf "app.kubernetes.io/instance: %s" ( .Release.Name ) | nindent 8 }}
+{{- printf "app.kubernetes.io/managed-by: %s" ( .Release.Service ) | nindent 8 }}
+{{- printf "app.kubernetes.io/name: %s" ( include "name" . ) | nindent 8 }}
+{{- printf "app.kubernetes.io/version: %s" ( .Chart.AppVersion ) | nindent 8 }}
+{{- printf "giantswarm.io/service_type: managed" | nindent 8 }}
+{{- printf "helm.sh/chart: %s" ( include "chart" . ) | nindent 8 }}
+{{- if (.Values.kustomizeController.podTemplate.labels) -}}
+{{- range $k, $v := .Values.kustomizeController.podTemplate.labels }}
+{{- $k | nindent 8 }}: {{ $v }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+

--- a/helm/flux-app/templates/install.yaml
+++ b/helm/flux-app/templates/install.yaml
@@ -684,27 +684,8 @@ spec:
       app.kubernetes.io/name: {{ include "name" . }}
   template:
     metadata:
-      annotations:
-        prometheus.io/port: "8080"
-        prometheus.io/scrape: "true"
-{{- if (.Values.kustomizeController.podTemplate.annotations) }}
-{{- range $k, $v := .Values.kustomizeController.podTemplate.annotations }}
-        {{ $k }}: {{ $v }}
-{{- end }}
-{{- end }}
-      labels:
-        app: kustomize-controller
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ include "name" . }}
-        app.kubernetes.io/version: {{ .Chart.AppVersion }}
-        giantswarm.io/service_type: managed
-        helm.sh/chart: {{ include "chart" . }}
-{{- if (.Values.kustomizeController.podTemplate.labels) }}
-{{- range $k, $v := .Values.kustomizeController.podTemplate.labels }}
-        {{ $k }}: {{ $v }}
-{{- end }}
-{{- end }}
+      annotations: {{ include "podTemplateAnnotations.kustomizeController" . }}
+      labels: {{ include "podTemplateLabels.kustomizeController" . }}
     spec:
       containers:
         - args:

--- a/helm/flux-app/templates/install.yaml
+++ b/helm/flux-app/templates/install.yaml
@@ -687,6 +687,11 @@ spec:
       annotations:
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
+{{- if (.Values.kustomizeController.podTemplate.annotations) }}
+{{- range $k, $v := .Values.kustomizeController.podTemplate.annotations }}
+        {{ $k }}: {{ $v }}
+{{- end }}
+{{- end }}
       labels:
         app: kustomize-controller
         app.kubernetes.io/instance: {{ .Release.Name }}
@@ -695,6 +700,11 @@ spec:
         app.kubernetes.io/version: {{ .Chart.AppVersion }}
         giantswarm.io/service_type: managed
         helm.sh/chart: {{ include "chart" . }}
+{{- if (.Values.kustomizeController.podTemplate.labels) }}
+{{- range $k, $v := .Values.kustomizeController.podTemplate.labels }}
+        {{ $k }}: {{ $v }}
+{{- end }}
+{{- end }}
     spec:
       containers:
         - args:

--- a/helm/flux-app/values.schema.json
+++ b/helm/flux-app/values.schema.json
@@ -345,6 +345,20 @@
       "properties": {
         "annotations": {"type": "object"}
       }
+    },
+    "kustomizeController": {
+      "type": "object",
+      "required": ["podTemplate"],
+      "properties": {
+        "podTemplate": {
+          "type": "object",
+          "required": ["annotations", "labels"],
+          "properties": {
+            "annotations": {"type": "object"},
+            "labels": {"type": "object"}
+          }
+        }
+      }
     }
   },
   "additionalProperties": true

--- a/helm/flux-app/values.yaml
+++ b/helm/flux-app/values.yaml
@@ -134,3 +134,9 @@ volumes:
 # KMS keys.
 kustomizeServiceAccount:
   annotations: {}
+
+# Provides the ability to add custom labels and annotations to
+kustomizeController:
+  podTemplate:
+    annotations: {}
+    labels: {}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/24857

This introduces the capability of adding custom annotations and labels to the kustomize-controller pod template.

The effect of this is to allow integration with additional components such as `workload-identity` which need labels adding to the pods for them to be injected with credentials for connecting to cloud components such as for GCP KMS.