### PR TITLE
Adding TTL

### DIFF
--- a/helm/flux-app/templates/crd-install/crd-job.yaml
+++ b/helm/flux-app/templates/crd-install/crd-job.yaml
@@ -13,6 +13,7 @@ metadata:
     {{- include "labels.selector" . | nindent 4 }}
     role: {{ include "crdInstallSelector" . | quote }}
 spec:
+  ttlSecondsAfterFinished: 3600
   template:
     metadata:
       labels:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/24890

**TL;DR**
For `flux-giantswarm` we do not use Helm to install the app, but we instead use to build the resources, which are later applied, so the Helm hooks are of no use. When the Job is already present in the cluster, and when it differs in comparison to what is being now provided by the app, this may result in an error. I think we may provide the TTL mechanism so that the Job is cleaned up by Kubernetes, yet I think the time should be high enough to give us or others time to debug potential issues. We can make it configurable or fixed.

Yet, I'm not sure if all the Kubernetes versions supports this field.