### PR TITLE
User supplied values for labels should be quoted

### DIFF
--- a/helm/flux-app/templates/_helpers.tpl
+++ b/helm/flux-app/templates/_helpers.tpl
@@ -159,7 +159,7 @@ limits:
 {{- printf "helm.sh/chart: %s" ( include "chart" . ) | nindent 8 }}
 {{- if (.Values.kustomizeController.podTemplate.labels) -}}
 {{- range $k, $v := .Values.kustomizeController.podTemplate.labels }}
-{{- $k | nindent 8 }}: {{ $v }}
+{{- $k | nindent 8 }}: {{ $v | quote }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm/flux-app/values.yaml
+++ b/helm/flux-app/values.yaml
@@ -139,5 +139,4 @@ kustomizeServiceAccount:
 kustomizeController:
   podTemplate:
     annotations: {}
-    labels:
-      test: true
+    labels: {}

--- a/helm/flux-app/values.yaml
+++ b/helm/flux-app/values.yaml
@@ -139,4 +139,5 @@ kustomizeServiceAccount:
 kustomizeController:
   podTemplate:
     annotations: {}
-    labels: {}
+    labels:
+      test: true


### PR DESCRIPTION
There's a missing `| quote` on the helper for the labels which get assigned to pod template. This PR adds this