### PR TITLE
Adding new flag for feature gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Introduce interface for disabling feature gates.
+
 ## [0.20.1] - 2022-12-09
 
 - Fixed quoting of pod template labels

--- a/hack/patches/image-automation-controller-deploy-patch.yaml
+++ b/hack/patches/image-automation-controller-deploy-patch.yaml
@@ -7,3 +7,6 @@
 - op: replace
   path: /spec/template/spec/containers/0/args/0
   value: --events-addr=http://notification-controller.{{ .Release.Namespace }}.svc.{{ .Values.cluster.domain }}./
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --feature-gates={{ include "imageAutomationController.featureGates" . }}

--- a/helm/flux-app/templates/_helpers.tpl
+++ b/helm/flux-app/templates/_helpers.tpl
@@ -164,3 +164,13 @@ limits:
 {{- end -}}
 {{- end -}}
 
+{{/*
+Generate feature gates argument
+*/}}
+{{- define "imageAutomationController.featureGates" -}}
+{{- $arg := "" }}
+{{- range $k := .Values.imageAutomationController.featureGatesToDisable -}}
+{{- $arg = (printf "%s%s=false," $arg $k) }}
+{{- end -}}
+{{- trimSuffix "," (printf $arg) }}
+{{- end -}}

--- a/helm/flux-app/templates/install.yaml
+++ b/helm/flux-app/templates/install.yaml
@@ -467,7 +467,7 @@ spec:
             httpGet:
               path: /readyz
               port: healthz
-          resources: 
+          resources:
 {{ include "resources.helmController" . | indent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -529,6 +529,7 @@ spec:
             - --log-level=info
             - --log-encoding=json
             - --enable-leader-election
+            - --feature-gates={{ include "imageAutomationController.featureGates" . }}
           env:
             - name: RUNTIME_NAMESPACE
               valueFrom:
@@ -552,7 +553,7 @@ spec:
             httpGet:
               path: /readyz
               port: healthz
-          resources: 
+          resources:
 {{ include "resources.imageAutomationController" . | indent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -637,7 +638,7 @@ spec:
             httpGet:
               path: /readyz
               port: healthz
-          resources: 
+          resources:
 {{ include "resources.imageReflectorController" . | indent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -717,7 +718,7 @@ spec:
             httpGet:
               path: /readyz
               port: healthz
-          resources: 
+          resources:
 {{ include "resources.kustomizeController" . | indent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -807,7 +808,7 @@ spec:
             httpGet:
               path: /readyz
               port: healthz
-          resources: 
+          resources:
 {{ include "resources.notificationController" . | indent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -901,7 +902,7 @@ spec:
             httpGet:
               path: /
               port: http
-          resources: 
+          resources:
 {{ include "resources.sourceController" . | indent 12 }}
           securityContext:
             allowPrivilegeEscalation: false

--- a/helm/flux-app/values.schema.json
+++ b/helm/flux-app/values.schema.json
@@ -359,6 +359,19 @@
           }
         }
       }
+    },
+    "imageAutomationController": {
+      "type": "object",
+      "required": ["featureGatesToDisable"],
+      "properties": {
+        "featureGatesToDisable": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["GitForcePushBranch", "ForceGoGitImplementation"]
+          }
+        }
+      }
     }
   },
   "additionalProperties": true

--- a/helm/flux-app/values.yaml
+++ b/helm/flux-app/values.yaml
@@ -140,3 +140,13 @@ kustomizeController:
   podTemplate:
     annotations: {}
     labels: {}
+
+# Interface to provide extra configuration to the Image Automation Controller
+imageAutomationController:
+  # featureGates is the []string type, listing feature gates name to disable,
+  # which are otherwise enabled by default.
+  #
+  # featureGatesToDisable:
+  #   - GitForcePushBranch
+  #   - ForceGoGitImplementation
+  featureGatesToDisable: []


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/1773

TL;DR: this can be done even simpler way by introducing string variable in the `values.yaml` that can be passed comma-separated list of feature gates and their values, so the exact value the flag expects, but I thought doing this with array has a nicer touch. Since the feature flags are all enabled by default, we must care only for giving a way to disable them, also an empty list may be passed to the controller, which is a nice thing as it relieve us from doing bumbo jump in our `hack` directory.

