### PR TITLE
Fixing two step install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+Fixed condition for internal upgrade.
+
 ### Changed
 
 - Control CPU limits and min allowed CPU + memory requests with VPA as well for flux controllers

--- a/helm/flux-app/templates/source.yaml
+++ b/helm/flux-app/templates/source.yaml
@@ -1,4 +1,7 @@
-{{- $two_step_upgrade := include "appPlatform.twoStepInstall" .Release.Name | fromYaml }}
+{{- $two_step_upgrade := printf "unsupported: true" | fromYaml }}
+{{- if (.Capabilities.APIVersions.Has "application.giantswarm.io/v1alpha1") }}
+{{- $two_step_upgrade = include "appPlatform.twoStepInstall" .Release.Name | fromYaml }}
+{{- end }}
 {{- if .Values.sopsEncryption.enabled }}
 apiVersion: v1
 data:


### PR DESCRIPTION
This to for the non-GS clusters that do not have the App Platform API available. It should have been introduced when I was introducing two step install, but apparently I missed that. This is however not of high priority, for it is unlikely that people install Charts from our catalogs outside the GS clusters.