### PR TITLE
Adding a dedicated PriorityClass for Flux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `PriorityClass`.
+- Added `CiliumNetworkPolicy`.
+
 ## [0.21.2] - 2023-02-03
 
 ### Fixed

--- a/hack/kustomization.yaml
+++ b/hack/kustomization.yaml
@@ -84,3 +84,8 @@ patches:
     version: v1
     kind: Deployment
     labelSelector: "app.kubernetes.io/instance=flux-system"
+- path: ./patches/all-deployments-patch.yaml
+  target:
+    group: apps
+    version: v1
+    kind: Deployment

--- a/hack/patches/all-deployments-patch.yaml
+++ b/hack/patches/all-deployments-patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/priorityClassName
+  value: '{{ include "priorityClass.name" . }}'

--- a/helm/flux-app/templates/_helpers.tpl
+++ b/helm/flux-app/templates/_helpers.tpl
@@ -187,3 +187,14 @@ Generate Kustomize Controller SA's annotations
 {{- end -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+Define name of the PriorityClass.
+*/}}
+{{- define "priorityClass.name" -}}
+{{- if .Values.priorityClass.name }}
+{{- .Values.priorityClass.name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Namespace .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}

--- a/helm/flux-app/templates/install.yaml
+++ b/helm/flux-app/templates/install.yaml
@@ -462,7 +462,7 @@ spec:
             httpGet:
               path: /readyz
               port: healthz
-          resources: 
+          resources:
 {{ include "resources.helmController" . | indent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -475,6 +475,7 @@ spec:
         fsGroup: 1337
       serviceAccountName: helm-controller
       terminationGracePeriodSeconds: 600
+      priorityClassName: {{ include "priorityClass.name" . }}
       volumes:
         - emptyDir: {}
           name: temp
@@ -548,7 +549,7 @@ spec:
             httpGet:
               path: /readyz
               port: healthz
-          resources: 
+          resources:
 {{ include "resources.imageAutomationController" . | indent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -561,6 +562,7 @@ spec:
         fsGroup: 1337
       serviceAccountName: image-automation-controller
       terminationGracePeriodSeconds: 10
+      priorityClassName: {{ include "priorityClass.name" . }}
       volumes:
         - emptyDir: {}
           name: temp
@@ -633,7 +635,7 @@ spec:
             httpGet:
               path: /readyz
               port: healthz
-          resources: 
+          resources:
 {{ include "resources.imageReflectorController" . | indent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -648,6 +650,7 @@ spec:
         fsGroup: 1337
       serviceAccountName: image-reflector-controller
       terminationGracePeriodSeconds: 10
+      priorityClassName: {{ include "priorityClass.name" . }}
       volumes:
         - emptyDir: {}
           name: temp
@@ -713,7 +716,7 @@ spec:
             httpGet:
               path: /readyz
               port: healthz
-          resources: 
+          resources:
 {{ include "resources.kustomizeController" . | indent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -726,6 +729,7 @@ spec:
         fsGroup: 1337
       serviceAccountName: kustomize-controller
       terminationGracePeriodSeconds: 60
+      priorityClassName: {{ include "priorityClass.name" . }}
       volumes:
         - emptyDir: {}
           name: temp
@@ -803,7 +807,7 @@ spec:
             httpGet:
               path: /readyz
               port: healthz
-          resources: 
+          resources:
 {{ include "resources.notificationController" . | indent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -816,6 +820,7 @@ spec:
         fsGroup: 1337
       serviceAccountName: notification-controller
       terminationGracePeriodSeconds: 10
+      priorityClassName: {{ include "priorityClass.name" . }}
       volumes:
         - emptyDir: {}
           name: temp
@@ -897,7 +902,7 @@ spec:
             httpGet:
               path: /
               port: http
-          resources: 
+          resources:
 {{ include "resources.sourceController" . | indent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -912,6 +917,7 @@ spec:
         fsGroup: 1337
       serviceAccountName: source-controller
       terminationGracePeriodSeconds: 10
+      priorityClassName: {{ include "priorityClass.name" . }}
       volumes:
         - emptyDir: {}
           name: data

--- a/helm/flux-app/templates/priorityclass.yaml
+++ b/helm/flux-app/templates/priorityclass.yaml
@@ -1,0 +1,7 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ include "priorityClass.name" . }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+value: {{ int .Values.priorityClass.value }}

--- a/helm/flux-app/values.yaml
+++ b/helm/flux-app/values.yaml
@@ -150,3 +150,7 @@ imageAutomationController:
   #   - GitForcePushBranch
   #   - ForceGoGitImplementation
   featureGatesToDisable: []
+
+priorityClass:
+  name: ""
+  value: 1000000000


### PR DESCRIPTION
Adding a new `PriorityClass` is not fully justified in the sense, the `giantswarm-critical` `PriorityClass`, of the same purpose, is often available in MCs and possibly the WCs as well, BUT I am not sure this availability is something I can always count on. I mean, the existence of the `giantswarm-critical` seems like kind of gray area to me, for example there is a part of `mc-bootstrap` that can create it, but there is also Chart Operator which is being able to provide it, so to avoid potential problems when installing an app it feels justified to create app's own resource.

Towards: https://github.com/giantswarm/giantswarm/issues/25698