### PR TITLE
[DO NOT MERGE] Add a switch to disable PSPs via values

### DIFF
--- a/helm/flux-app/Chart.yaml
+++ b/helm/flux-app/Chart.yaml
@@ -20,4 +20,4 @@ restrictions:
 sources:
   - https://github.com/fluxcd/flux2
 type: application
-version: 1.1.1
+version: 1.1.2

--- a/helm/flux-app/templates/crd-install/crd-psp.yaml
+++ b/helm/flux-app/templates/crd-install/crd-psp.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.crds.install }}
+{{- if not .Values.global.podSecurityStandards.enforced }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -37,4 +38,5 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
+{{- end }}
 {{- end }}

--- a/helm/flux-app/templates/crd-install/crd-rbac.yaml
+++ b/helm/flux-app/templates/crd-install/crd-rbac.yaml
@@ -29,6 +29,7 @@ rules:
   - delete
   - get
   - patch
+{{- if not .Values.global.podSecurityStandards.enforced }}
 - apiGroups:
   - policy
   resources:
@@ -37,6 +38,7 @@ rules:
   - {{ include "crdInstall" . }}
   verbs:
   - use
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/helm/flux-app/templates/install.yaml
+++ b/helm/flux-app/templates/install.yaml
@@ -112,6 +112,8 @@ metadata:
     helm.sh/chart: {{ include "chart" . }}
   name: source-controller
   namespace: {{ .Release.Namespace }}
+
+{{- if not .Values.global.podSecurityStandards.enforced }}
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -148,6 +150,7 @@ spec:
   volumes:
     - emptyDir
     - secret
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -242,6 +245,7 @@ rules:
       - update
       - patch
       - delete
+  {{- if not .Values.global.podSecurityStandards.enforced }}
   - apiGroups:
       - policy
     resourceNames:
@@ -250,6 +254,7 @@ rules:
       - podsecuritypolicies
     verbs:
       - use
+  {{- end }}
 {{- if .Values.clusterRoles.install }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/flux-app/templates/policy-exception.yaml
+++ b/helm/flux-app/templates/policy-exception.yaml
@@ -10,6 +10,8 @@ metadata:
 apiVersion: kyverno.io/v2alpha1
 kind: PolicyException
 metadata:
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
   name: flux-app
   namespace: policy-exceptions
 spec:

--- a/helm/flux-app/values.yaml
+++ b/helm/flux-app/values.yaml
@@ -156,3 +156,7 @@ containerSecurityContext:
     drop:
       - ALL
   runAsNonRoot: true
+
+global:
+  podSecurityStandards:
+    enforced: false


### PR DESCRIPTION
We require PSPs to be installed on k8s < 1.25, and since in the flux-app 1.2.0 PSPs were dumped completely, it can't be installed on most of our clusters anymore. Adding PSPs to the 1.2.* seems like a bad idea, since they were removed because of deprecation. That's why I'm adding a switch as a patch to 1.1.*. During the migration we will be able to use this version, and once 1.25 is our default k8s version, we can upgrade to flux-app 1.2.* or greater