### PR TITLE
Add a switch to enable/disable PSPs via values

### DIFF
--- a/helm/flux-app/Chart.yaml
+++ b/helm/flux-app/Chart.yaml
@@ -20,4 +20,4 @@ restrictions:
 sources:
   - https://github.com/fluxcd/flux2
 type: application
-version: 1.2.0
+version: 1.2.1

--- a/helm/flux-app/templates/crd-install/crd-psp.yaml
+++ b/helm/flux-app/templates/crd-install/crd-psp.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.crds.install }}
+{{- if not .Values.global.podSecurityStandards.enforced }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "crdInstall" . }}
+  annotations:
+    {{- if ge (int .Capabilities.KubeVersion.Minor) 19 }}
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
+    {{- end }}
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-6"
+    {{- include "crdInstallAnnotations" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "crdInstall" . | quote }}
+    {{- include "labels.selector" . | nindent 4 }}
+    role: {{ include "crdInstallSelector" . | quote }}
+spec:
+  privileged: false
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  volumes:
+  - 'configMap'
+  - 'projected'
+  hostPID: false
+  hostIPC: false
+  hostNetwork: false
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}
+{{- end }}

--- a/helm/flux-app/templates/crd-install/crd-rbac.yaml
+++ b/helm/flux-app/templates/crd-install/crd-rbac.yaml
@@ -29,6 +29,7 @@ rules:
   - delete
   - get
   - patch
+{{- if not .Values.global.podSecurityStandards.enforced }}
 - apiGroups:
   - policy
   resources:
@@ -37,6 +38,7 @@ rules:
   - {{ include "crdInstall" . }}
   verbs:
   - use
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/helm/flux-app/templates/policy-exception.yaml
+++ b/helm/flux-app/templates/policy-exception.yaml
@@ -1,3 +1,4 @@
+{{ if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" }}
 ---
 apiVersion: kyverno.io/v2alpha1
 kind: PolicyException
@@ -50,3 +51,4 @@ spec:
           - "flux-app-crd-install*"
         namespaces:
         - "{{ .Release.Namespace }}"
+{{- end }}

--- a/helm/flux-app/templates/policy-exception.yaml
+++ b/helm/flux-app/templates/policy-exception.yaml
@@ -1,10 +1,3 @@
-{{ if not (lookup "v1" "Namespace" "" "policy-exceptions") -}}
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: policy-exceptions
-{{- end }}
 ---
 apiVersion: kyverno.io/v2alpha1
 kind: PolicyException

--- a/helm/flux-app/templates/policy-exception.yaml
+++ b/helm/flux-app/templates/policy-exception.yaml
@@ -1,4 +1,3 @@
-{{ if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" }}
 {{ if not (lookup "v1" "Namespace" "" "policy-exceptions") -}}
 ---
 apiVersion: v1
@@ -12,6 +11,8 @@ kind: PolicyException
 metadata:
   name: flux-app
   namespace: policy-exceptions
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
 spec:
   background: true
   exceptions:
@@ -56,4 +57,3 @@ spec:
           - "flux-app-crd-install*"
         namespaces:
         - "{{ .Release.Namespace }}"
-{{- end }}

--- a/helm/flux-app/templates/psp/_helpers.tpl
+++ b/helm/flux-app/templates/psp/_helpers.tpl
@@ -1,0 +1,12 @@
+{{- define "pspName" -}}
+{{ printf "%s-pvc-psp" (include "name" .)}}
+{{- end }}
+
+{{- define "pspNameFinal" }}
+{{- if .Values.namePostfix }}
+{{- printf "%s-%s" (include "pspName" .) .Values.namePostfix }}
+{{ else }}
+{{- include "pspName" . }}
+{{ end }}
+{{- end -}}
+

--- a/helm/flux-app/templates/psp/psp.yaml
+++ b/helm/flux-app/templates/psp/psp.yaml
@@ -1,0 +1,39 @@
+# PSP were removed in k8s 1.25
+# but we still require them in older versions
+{{- if not .Values.global.podSecurityStandards.enforced }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  {{- if ge (int .Capabilities.KubeVersion.Minor) 19 }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: "runtime/default"
+  {{- end }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    giantswarm.io/service_type: managed
+    helm.sh/chart: {{ include "chart" . }}
+  name: {{ printf "%s-pvc-psp" (include "name" .) }}
+spec:
+  allowPrivilegeEscalation: false
+  fsGroup:
+    ranges:
+      - max: 65535
+        min: 1
+    rule: MustRunAs
+  privileged: false
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+      - max: 65535
+        min: 1
+    rule: MustRunAs
+  volumes:
+    - emptyDir
+    - secret
+{{- end }}

--- a/helm/flux-app/templates/psp/psp.yaml
+++ b/helm/flux-app/templates/psp/psp.yaml
@@ -15,7 +15,7 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     giantswarm.io/service_type: managed
     helm.sh/chart: {{ include "chart" . }}
-  name: {{ printf "%s-pvc-psp" (include "name" .) }}
+  name: {{ include "pspNameFinal" . }}
 spec:
   allowPrivilegeEscalation: false
   fsGroup:

--- a/helm/flux-app/templates/psp/rbac.yaml
+++ b/helm/flux-app/templates/psp/rbac.yaml
@@ -11,12 +11,12 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     giantswarm.io/service_type: managed
     helm.sh/chart: {{ include "chart" . }}
-  name: flux-psp
+  name: {{ include "pspNameFinal" . }}
 rules:
   - apiGroups:
       - policy
     resourceNames:
-      - {{ printf "%s-pvc-psp" (include "name" .) }}
+      - {{ include "pspNameFinal" . }}
     resources:
       - podsecuritypolicies
     verbs:
@@ -33,7 +33,7 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     giantswarm.io/service_type: managed
     helm.sh/chart: {{ include "chart" . }}
-  name: flux-psp-binding
+  name: {{ include "pspNameFinal" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/helm/flux-app/templates/psp/rbac.yaml
+++ b/helm/flux-app/templates/psp/rbac.yaml
@@ -1,0 +1,60 @@
+{{- if not .Values.global.podSecurityStandards.enforced }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
+    app.kubernetes.io/part-of: flux
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    giantswarm.io/service_type: managed
+    helm.sh/chart: {{ include "chart" . }}
+  name: flux-psp
+rules:
+  - apiGroups:
+      - policy
+    resourceNames:
+      - {{ printf "%s-pvc-psp" (include "name" .) }}
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "name" . }}
+    app.kubernetes.io/part-of: flux
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    giantswarm.io/service_type: managed
+    helm.sh/chart: {{ include "chart" . }}
+  name: crd-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flux-psp
+subjects:
+  - kind: ServiceAccount
+    name: kustomize-controller
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: helm-controller
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: source-controller
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: notification-controller
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: image-reflector-controller
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: image-automation-controller
+    namespace: {{ .Release.Namespace }}}
+{{- end }}

--- a/helm/flux-app/templates/psp/rbac.yaml
+++ b/helm/flux-app/templates/psp/rbac.yaml
@@ -33,7 +33,7 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     giantswarm.io/service_type: managed
     helm.sh/chart: {{ include "chart" . }}
-  name: psp-binding
+  name: flux-psp-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/helm/flux-app/templates/psp/rbac.yaml
+++ b/helm/flux-app/templates/psp/rbac.yaml
@@ -33,7 +33,7 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     giantswarm.io/service_type: managed
     helm.sh/chart: {{ include "chart" . }}
-  name: crd-controller
+  name: psp-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/helm/flux-app/values.yaml
+++ b/helm/flux-app/values.yaml
@@ -160,3 +160,8 @@ containerSecurityContext:
 global:
   podSecurityStandards:
     enforced: false
+
+# It should be used for making it possible to install this chart several times
+# without having cluster-wide resources conflicting.
+# It's not applied everywhere yet, so don't rely on that yet.
+namePostfix: giantswarm

--- a/helm/flux-app/values.yaml
+++ b/helm/flux-app/values.yaml
@@ -156,3 +156,7 @@ containerSecurityContext:
     drop:
       - ALL
   runAsNonRoot: true
+
+global:
+  podSecurityStandards:
+    enforced: false

--- a/helm/flux-app/values.yaml
+++ b/helm/flux-app/values.yaml
@@ -164,4 +164,4 @@ global:
 # It should be used for making it possible to install this chart several times
 # without having cluster-wide resources conflicting.
 # It's not applied everywhere yet, so don't rely on that yet.
-namePostfix: giantswarm
+namePostfix: ""


### PR DESCRIPTION
We require PSPs to be installed on k8s < 1.25, and since in the flux-app 1.2.0 PSPs were dumped completely, it can't be installed on most of our clusters anymore.