### PR TITLE
Bump generated source and kustomiations to v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump generated sources and kustomizations to v1.
+
 ## [1.3.1] - 2024-02-13
 
 ### Added

--- a/helm/flux-app/templates/source.yaml
+++ b/helm/flux-app/templates/source.yaml
@@ -18,7 +18,7 @@ metadata:
 {{- $is_gitrepository_crd := (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "gitrepositories.source.toolkit.fluxcd.io") -}}
 {{- if or $two_step_upgrade.unsupported $is_gitrepository_crd }}
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: "{{ .name }}"
@@ -61,7 +61,7 @@ spec:
 {{- $is_kustomization_crd := (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "kustomizations.kustomize.toolkit.fluxcd.io") -}}
 {{- if or $two_step_upgrade.unsupported $is_kustomization_crd }}
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: "{{ .name }}"


### PR DESCRIPTION
Since we bumped in MCB + CMC repos as well, it makes sense to use the up to date CRDs for new resources. We don't have or support adding any of the deprecated fields on them.