### PR TITLE
Change label giantswarm.io/service_type to giantswarm.io/service-type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix resource labelling from `giantswarm.io/service_type` to `giantswarm.io/service-type`.
+
 ## [1.4.0] - 2024-03-07
 
 ### Changed

--- a/helm/flux-app/templates/_helpers.tpl
+++ b/helm/flux-app/templates/_helpers.tpl
@@ -21,7 +21,7 @@ Common labels
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 helm.sh/chart: {{ include "chart" . | quote }}
-giantswarm.io/service_type: managed
+giantswarm.io/service-type: managed
 {{- end -}}
 
 {{/*
@@ -156,7 +156,7 @@ limits:
 {{- printf "app.kubernetes.io/managed-by: %s" ( .Release.Service ) | nindent 8 }}
 {{- printf "app.kubernetes.io/name: %s" ( include "name" . ) | nindent 8 }}
 {{- printf "app.kubernetes.io/version: %s" ( .Chart.AppVersion ) | nindent 8 }}
-{{- printf "giantswarm.io/service_type: managed" | nindent 8 }}
+{{- printf "giantswarm.io/service-type: managed" | nindent 8 }}
 {{- printf "helm.sh/chart: %s" ( include "chart" . ) | nindent 8 }}
 {{- if (.Values.kustomizeController.podTemplate.labels) -}}
 {{- range $k, $v := .Values.kustomizeController.podTemplate.labels }}

--- a/helm/flux-app/templates/base/deployment-helm-controller.yaml
+++ b/helm/flux-app/templates/base/deployment-helm-controller.yaml
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "name" . }}
         app.kubernetes.io/version: {{ .Chart.AppVersion }}
-        giantswarm.io/service_type: managed
+        giantswarm.io/service-type: managed
     spec:
       containers:
         - args:

--- a/helm/flux-app/templates/base/deployment-image-automation-controller.yaml
+++ b/helm/flux-app/templates/base/deployment-image-automation-controller.yaml
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "name" . }}
         app.kubernetes.io/version: {{ .Chart.AppVersion }}
-        giantswarm.io/service_type: managed
+        giantswarm.io/service-type: managed
         helm.sh/chart: {{ include "chart" . }}
     spec:
       containers:

--- a/helm/flux-app/templates/base/deployment-image-reflector-controller.yaml
+++ b/helm/flux-app/templates/base/deployment-image-reflector-controller.yaml
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "name" . }}
         app.kubernetes.io/version: {{ .Chart.AppVersion }}
-        giantswarm.io/service_type: managed
+        giantswarm.io/service-type: managed
         helm.sh/chart: {{ include "chart" . }}
     spec:
       containers:

--- a/helm/flux-app/templates/base/deployment-notification-controller.yaml
+++ b/helm/flux-app/templates/base/deployment-notification-controller.yaml
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "name" . }}
         app.kubernetes.io/version: {{ .Chart.AppVersion }}
-        giantswarm.io/service_type: managed
+        giantswarm.io/service-type: managed
         helm.sh/chart: {{ include "chart" . }}
     spec:
       containers:

--- a/helm/flux-app/templates/base/deployment-source-controller.yaml
+++ b/helm/flux-app/templates/base/deployment-source-controller.yaml
@@ -28,7 +28,7 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "name" . }}
         app.kubernetes.io/version: {{ .Chart.AppVersion }}
-        giantswarm.io/service_type: managed
+        giantswarm.io/service-type: managed
         helm.sh/chart: {{ include "chart" . }}
     spec:
       containers:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30178

Note: There is this file which still carries the wrong label name.

https://github.com/giantswarm/flux-app/blob/911e413f8cfce56e28f9b1528d50bcd92544c464/hack/git-patches/011-old-selector-labels.patch#L28

Should this be adapted, too?