### PR TITLE
Update PolicyExceptions to v2beta1

### DIFF
--- a/helm/flux-app/templates/extras/policy-exception.yaml
+++ b/helm/flux-app/templates/extras/policy-exception.yaml
@@ -1,4 +1,4 @@
-{{- if or (.Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException") (eq .Values.policyException.enforce true) }}
+{{- if or (.Capabilities.APIVersions.Has "kyverno.io/v2beta1/PolicyException") (eq .Values.policyException.enforce true) }}
 apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:

--- a/helm/flux-app/templates/extras/policy-exception.yaml
+++ b/helm/flux-app/templates/extras/policy-exception.yaml
@@ -1,5 +1,5 @@
 {{- if or (.Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException") (eq .Values.policyException.enforce true) }}
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: {{ .Release.Name | quote }}


### PR DESCRIPTION
### Related issue: https://github.com/giantswarm/giantswarm/issues/30726

## Description

We need to update the PolicyExceptions apiVersion to v2beta1 as v2alpha1 is being removed in the next Kyverno release.