### PR TITLE
chore: bumping Flux API versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update API version of Flux resources to one considered stable in 2.6.
+
 ## [1.10.0] - 2026-04-08
 
 ### Changed

--- a/helm/flux-app/templates/source.yaml
+++ b/helm/flux-app/templates/source.yaml
@@ -45,7 +45,7 @@ data:
 {{- $is_provider_crd := (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "providers.notification.toolkit.fluxcd.io") -}}
 {{- if or $two_step_upgrade.unsupported $is_provider_crd }}
 ---
-apiVersion: notification.toolkit.fluxcd.io/v1beta1
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Provider
 metadata:
   name: "{{ .name }}-github-notification-provider"
@@ -87,7 +87,7 @@ spec:
 {{- $is_alert_crd := (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "alerts.notification.toolkit.fluxcd.io") -}}
 {{- if or $two_step_upgrade.unsupported $is_alert_crd }}
 ---
-apiVersion: notification.toolkit.fluxcd.io/v1beta1
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Alert
 metadata:
   name: "{{ .name }}-github-alert"


### PR DESCRIPTION
## Checklist

- [x] Update the changelog in CHANGELOG.md.
- [x] Make sure the Flux version introduced does not break the App Operator dependencies handling logic.
