### PR TITLE
chore: update giantswarm/docker-kubectl image to 1.36.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `giantswarm/docker-kubectl` image to 1.36.2.
+
 ## [1.10.1] - 2026-05-22
 
 ### Changed

--- a/helm/flux-app/templates/crd-install/crd-job.yaml
+++ b/helm/flux-app/templates/crd-install/crd-job.yaml
@@ -37,7 +37,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: kubectl
-        image: "{{ .Values.images.registry }}/giantswarm/docker-kubectl:1.23.6"
+        image: "{{ .Values.images.registry }}/giantswarm/docker-kubectl:1.36.2"
         command:
         - sh
         - -c


### PR DESCRIPTION
This new version is built for both amd and arm architectures.

## Checklist

- [x] Update the changelog in CHANGELOG.md.
- [x] Make sure the Flux version introduced does not break the App Operator dependencies handling logic.
